### PR TITLE
Feature/increase-range-of-acceptable-dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,22 +6,59 @@ image72: &image-72
   docker:
   - image: circleci/php:7.2-apache-stretch-node-browsers
 
-restore-cache: &restore-72-cache
+restore-71-cache: &restore-71-cache
+  restore_cache:
+      keys:
+      - v1-71-dependencies-{{ checksum "composer.lock" }}
+      - v1-71-dependencies-
+
+restore-72-cache: &restore-72-cache
   restore_cache:
       keys:
       - v1-72-dependencies-{{ checksum "composer.lock" }}
       - v1-72-dependencies-
 
-composer-install: &composer-install
-  run:
-    name: Composer install
-    command: composer install  --no-interaction --no-scripts --prefer-dist
+save-71-cache: &save-71-cache
+  save_cache:
+    key: v1-71-dependencies-{{ checksum "composer.lock" }}
+    paths:
+    - vendor
 
-save-cache: &save-72-cache
+save-72-cache: &save-72-cache
   save_cache:
     key: v1-72-dependencies-{{ checksum "composer.lock" }}
     paths:
     - vendor
+
+
+composer-install: &composer-install
+  run:
+    name: Composer install
+    command: composer install  --no-interaction --no-scripts --prefer-dist
+    
+composer-update-lowest: &composer-update-lowest
+  run:
+    name: Downgrade to lowest packages
+    command: composer update --prefer-lowest
+
+composer-update: &composer-update
+  run:
+    name: Updrade to highest packages
+    command: composer update --prefer-lowest
+
+ci: &ci
+  run:
+    name: Run CI
+    command: composer ci
+
+store-test-results: &store-test-results
+  store-test-results:
+    path: reports
+    
+store-artifacts: &store-artifacts
+  store-artifacts:
+    path: reports
+
 
 
 
@@ -29,25 +66,46 @@ version: 2
 
 jobs:
 
-  build-71:
+  build-71-lowest:
     <<: *image-71
 
     steps:
       - checkout
-      - restore_cache:
-          keys:
-          - v1-71-dependencies-{{ checksum "composer.lock" }}
-          - v1-71-dependencies-
+      - *restore-71-cache
       - *composer-install
-      - save_cache:
-          key: v1-dependencies-{{ checksum "composer.lock" }}
-          paths:
-          - vendor
-      - run:
-          name: Run full CI process
-          command: composer ci
+      - *save-71-cache
+      - *composer-update-lowest
+      - *ci
+      - *store-test-results
+      - *store-artifacts
 
-  build-72:
+  build-71-current:
+    <<: *image-71
+
+    steps:
+      - checkout
+      - *restore-71-cache
+      - *composer-install
+      - *save-71-cache
+      - *ci
+      - *store-test-results
+      - *store-artifacts
+
+  build-71-highest:
+    <<: *image-71
+
+    steps:
+      - checkout
+      - *restore-71-cache
+      - *composer-install
+      - *save-71-cache
+      - *composer-update
+      - *ci
+      - *store-test-results
+      - *store-artifacts
+
+
+  build-72-lowest:
     <<: *image-72
 
     steps:
@@ -55,13 +113,37 @@ jobs:
       - *restore-72-cache
       - *composer-install
       - *save-72-cache
-      - run:
-          name: Run full CI process
-          command: composer ci
-      - store-test-results:
-          path: reports
-      - store-artifacts:
-          path: reports
+      - *composer-update-lowest
+      - *ci
+      - *store-test-results
+      - *store-artifacts
+
+  build-72-current:
+    <<: *image-72
+
+    steps:
+      - checkout
+      - *restore-72-cache
+      - *composer-install
+      - *save-72-cache
+      - *ci
+      - *store-test-results
+      - *store-artifacts
+
+  build-72-highest:
+    <<: *image-72
+
+    steps:
+      - checkout
+      - *restore-72-cache
+      - *composer-install
+      - *save-72-cache
+      - *composer-update
+      - *ci
+      - *store-test-results
+      - *store-artifacts
+
+
 
 
   security:
@@ -80,8 +162,12 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build-71
-      - build-72
+      - build-71-lowest
+      - build-71-current
+      - build-71-highest
+      - build-72-lowest
+      - build-72-current
+      - build-72-highest
 
   security-check:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,25 @@
-defaults: &image
+image71: &image-71
+  docker:
+  - image: circleci/php:7.1-apache-stretch-node-browsers
+
+image72: &image-72
   docker:
   - image: circleci/php:7.2-apache-stretch-node-browsers
 
-restore-cache: &restore-cache
+restore-cache: &restore-72-cache
   restore_cache:
       keys:
-      - v1-dependencies-{{ checksum "composer.lock" }}
-      - v1-dependencies-
+      - v1-72-dependencies-{{ checksum "composer.lock" }}
+      - v1-72-dependencies-
 
 composer-install: &composer-install
   run:
     name: Composer install
     command: composer install  --no-interaction --no-scripts --prefer-dist
 
-save-cache: &save-cache
+save-cache: &save-72-cache
   save_cache:
-    key: v1-dependencies-{{ checksum "composer.lock" }}
+    key: v1-72-dependencies-{{ checksum "composer.lock" }}
     paths:
     - vendor
 
@@ -24,14 +28,33 @@ save-cache: &save-cache
 version: 2
 
 jobs:
-  build:
-    <<: *image
+
+  build-71:
+    <<: *image-71
 
     steps:
       - checkout
-      - *restore-cache
+      - restore_cache:
+          keys:
+          - v1-71-dependencies-{{ checksum "composer.lock" }}
+          - v1-71-dependencies-
       - *composer-install
-      - *save-cache
+      - save_cache:
+          key: v1-dependencies-{{ checksum "composer.lock" }}
+          paths:
+          - vendor
+      - run:
+          name: Run full CI process
+          command: composer ci
+
+  build-72:
+    <<: *image-72
+
+    steps:
+      - checkout
+      - *restore-72-cache
+      - *composer-install
+      - *save-72-cache
       - run:
           name: Run full CI process
           command: composer ci
@@ -42,13 +65,13 @@ jobs:
 
 
   security:
-    <<: *image
+    <<: *image-72
 
     steps:
       - checkout
-      - *restore-cache
+      - *restore-72-cache
       - *composer-install
-      - *save-cache
+      - *save-72-cache
       - run:
           name: Run security check
           command: composer security
@@ -57,7 +80,8 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build-71
+      - build-72
 
   security-check:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,7 @@ workflows:
       - build-72-lowest
       - build-72-current
       - build-72-highest
+      - security
 
   security-check:
     triggers:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "webmozart/path-util": "^2.3"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.0",
+    "friendsofphp/php-cs-fixer": "^2.13.1",
     "jakub-onderka/php-parallel-lint": "~0.9",
     "jakub-onderka/php-var-dump-check": "~0.2",
     "phpstan/phpstan": "^0.10.5",

--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,7 @@
       "@cs",
       "@test",
       "@psalm",
-      "@phpstan",
-      "@security"
+      "@phpstan"
     ],
     "composer-validate" : "@composer validate --no-check-all --strict",
     "lint" : "parallel-lint src tests",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
   },
   "require": {
     "php": ">=7.1",
-    "symfony/config": "^4.1",
-    "symfony/console": "^4.1",
-    "symfony/dependency-injection": "^4.1",
-    "symfony/process": "^4.1",
-    "symfony/yaml": "^4.1",
+    "symfony/config": "^3.4 || ^4.0",
+    "symfony/console": "^3.4 || ^4.0",
+    "symfony/dependency-injection": "^3.4 || ^4.0",
+    "symfony/process": "^3.4 || ^4.0",
+    "symfony/yaml": "^3.4 || ^4.0",
     "webmozart/assert": "^1.3",
     "webmozart/path-util": "^2.3"
   },
@@ -32,7 +32,7 @@
     "phpstan/phpstan-webmozart-assert": "^0.10.0",
     "phpunit/phpunit": "^7.0",
     "sensiolabs/security-checker": "^5.0",
-    "symfony/filesystem": "^4.1",
+    "symfony/filesystem": "^3.4 || ^4.0",
     "vimeo/psalm": "^3.0.7"
   },
   "bin" : ["sarb"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2521aba245fb815963b077a2b77b9421",
+    "content-hash": "0a7579cc12a6f18510f4ee1365ad7be9",
     "packages": [
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0a7579cc12a6f18510f4ee1365ad7be9",
+    "content-hash": "139ee29c5cf281ac5d3d05f058442f87",
     "packages": [
         {
             "name": "psr/container",
@@ -57,16 +57,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.1.6",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "b3d4d7b567d7a49e6dfafb6d4760abc921177c96"
+                "reference": "005d9a083d03f588677d15391a716b1ac9b887c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/b3d4d7b567d7a49e6dfafb6d4760abc921177c96",
-                "reference": "b3d4d7b567d7a49e6dfafb6d4760abc921177c96",
+                "url": "https://api.github.com/repos/symfony/config/zipball/005d9a083d03f588677d15391a716b1ac9b887c0",
+                "reference": "005d9a083d03f588677d15391a716b1ac9b887c0",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -116,24 +116,25 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-09-08T13:24:10+00:00"
+            "time": "2018-11-30T22:21:14+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.1.6",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "dc7122fe5f6113cfaba3b3de575d31112c9aa60b"
+                "reference": "4dff24e5d01e713818805c1862d2e3f901ee7dd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/dc7122fe5f6113cfaba3b3de575d31112c9aa60b",
-                "reference": "dc7122fe5f6113cfaba3b3de575d31112c9aa60b",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4dff24e5d01e713818805c1862d2e3f901ee7dd0",
+                "reference": "4dff24e5d01e713818805c1862d2e3f901ee7dd0",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
+                "symfony/contracts": "^1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
@@ -157,7 +158,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -184,37 +185,107 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-03T08:15:46+00:00"
+            "time": "2018-11-27T07:40:44+00:00"
         },
         {
-            "name": "symfony/dependency-injection",
-            "version": "v4.1.6",
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "f6b9d893ad28aefd8942dc0469c8397e2216fe30"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f6b9d893ad28aefd8942dc0469c8397e2216fe30",
-                "reference": "f6b9d893ad28aefd8942dc0469c8397e2216fe30",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "e4adc57a48d3fa7f394edfffa9e954086d7740e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/e4adc57a48d3fa7f394edfffa9e954086d7740e5",
+                "reference": "e4adc57a48d3fa7f394edfffa9e954086d7740e5",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "psr/container": "^1.0"
+                "psr/container": "^1.0",
+                "symfony/contracts": "^1.0"
             },
             "conflict": {
-                "symfony/config": "<4.1.1",
+                "symfony/config": "<4.2",
                 "symfony/finder": "<3.4",
                 "symfony/proxy-manager-bridge": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "provide": {
-                "psr/container-implementation": "1.0"
+                "psr/container-implementation": "1.0",
+                "symfony/service-contracts-implementation": "1.0"
             },
             "require-dev": {
-                "symfony/config": "~4.1",
+                "symfony/config": "~4.2",
                 "symfony/expression-language": "~3.4|~4.0",
                 "symfony/yaml": "~3.4|~4.0"
             },
@@ -228,7 +299,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -255,20 +326,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:40:59+00:00"
+            "time": "2018-12-02T15:59:36+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.1.6",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "596d12b40624055c300c8b619755b748ca5cf0b5"
+                "reference": "2f4c8b999b3b7cadb2a69390b01af70886753710"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/596d12b40624055c300c8b619755b748ca5cf0b5",
-                "reference": "596d12b40624055c300c8b619755b748ca5cf0b5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2f4c8b999b3b7cadb2a69390b01af70886753710",
+                "reference": "2f4c8b999b3b7cadb2a69390b01af70886753710",
                 "shasum": ""
             },
             "require": {
@@ -278,7 +349,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -305,7 +376,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:40:59+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -426,16 +497,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.1.6",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "ee33c0322a8fee0855afcc11fff81e6b1011b529"
+                "reference": "2b341009ccec76837a7f46f59641b431e4d4c2b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/ee33c0322a8fee0855afcc11fff81e6b1011b529",
-                "reference": "ee33c0322a8fee0855afcc11fff81e6b1011b529",
+                "url": "https://api.github.com/repos/symfony/process/zipball/2b341009ccec76837a7f46f59641b431e4d4c2b0",
+                "reference": "2b341009ccec76837a7f46f59641b431e4d4c2b0",
                 "shasum": ""
             },
             "require": {
@@ -444,7 +515,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -471,20 +542,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T12:40:59+00:00"
+            "time": "2018-11-20T16:22:05+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.1.6",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9"
+                "reference": "c41175c801e3edfda90f32e292619d10c27103d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/367e689b2fdc19965be435337b50bc8adf2746c9",
-                "reference": "367e689b2fdc19965be435337b50bc8adf2746c9",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c41175c801e3edfda90f32e292619d10c27103d7",
+                "reference": "c41175c801e3edfda90f32e292619d10c27103d7",
                 "shasum": ""
             },
             "require": {
@@ -503,7 +574,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -530,7 +601,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-10-02T16:36:10+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
- Added CI build jobs for min/current/max range of packages for PHP versions 7.1 and 7.2
- Allow both ^3.4 and ^4.0 for Symfony dependencies
- Update use of Symfony's Process::__constructor method. In future only `array` will be allowed, not `string|array` 