### PR TITLE
FIX compare baseline against current code NOT most recent commit.

### DIFF
--- a/src/Plugins/GitDiffHistoryAnalyser/GitDiffHistoryFactory.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/GitDiffHistoryFactory.php
@@ -52,8 +52,7 @@ class GitDiffHistoryFactory implements HistoryFactory
     {
         /** @var GitCommit $baseLineHistoryMarker */
         Assert::isInstanceOf($baseLineHistoryMarker, GitCommit::class);
-        $newDiff = $this->gitCliWrapper->getCurrentSha($projectRoot);
-        $diff = $this->gitCliWrapper->getGitDiff($projectRoot, $baseLineHistoryMarker, $newDiff);
+        $diff = $this->gitCliWrapper->getGitDiff($projectRoot, $baseLineHistoryMarker);
         $fileMutations = $this->parser->parseDiff($diff);
 
         return new DiffHistoryAnalyser($fileMutations);

--- a/src/Plugins/GitDiffHistoryAnalyser/internal/GitCliWrapper.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/internal/GitCliWrapper.php
@@ -34,14 +34,13 @@ class GitCliWrapper implements GitWrapper
     /**
      * {@inheritdoc}
      */
-    public function getGitDiff(ProjectRoot $projectRoot, GitCommit $originalCommit, GitCommit $newCommit): string
+    public function getGitDiff(ProjectRoot $projectRoot, GitCommit $originalCommit): string
     {
-        $range = sprintf('%s..%s', $originalCommit->asString(), $newCommit->asString());
         $arguments = [
             'diff',
             '-w',
             '-M',
-            $range,
+            $originalCommit->asString(),
         ];
         $command = $this->getGitCommand($arguments, $projectRoot);
 
@@ -83,7 +82,7 @@ class GitCliWrapper implements GitWrapper
     {
         $gitCommand = [
             'git',
-            "--git-dir={$projectRoot}/.git",
+            '--git-dir='.$projectRoot.\DIRECTORY_SEPARATOR.'.git',
             "--work-tree={$projectRoot}",
         ];
 

--- a/src/Plugins/GitDiffHistoryAnalyser/internal/GitWrapper.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/internal/GitWrapper.php
@@ -31,9 +31,8 @@ interface GitWrapper
      *
      * @param ProjectRoot $projectRoot
      * @param GitCommit $originalCommit
-     * @param GitCommit $newCommit
      *
      * @return string
      */
-    public function getGitDiff(ProjectRoot $projectRoot, GitCommit $originalCommit, GitCommit $newCommit): string;
+    public function getGitDiff(ProjectRoot $projectRoot, GitCommit $originalCommit): string;
 }

--- a/tests/Unit/Plugins/GitDiffHistoryAnalyser/internal/StubGitWrapper.php
+++ b/tests/Unit/Plugins/GitDiffHistoryAnalyser/internal/StubGitWrapper.php
@@ -40,7 +40,7 @@ class StubGitWrapper implements GitWrapper
     /**
      * {@inheritdoc}
      */
-    public function getGitDiff(ProjectRoot $projectRoot, GitCommit $originalCommit, GitCommit $newCommit): string
+    public function getGitDiff(ProjectRoot $projectRoot, GitCommit $originalCommit): string
     {
         return $this->diff;
     }


### PR DESCRIPTION
Previously SARB generated a diff from the baseline commit and the most
recent commit. However static anlaysis might be run on the current
state of the code. These 2 might be different.

When running on CI the current state of the code and latest commit will
_probably_ be the same.

Developing locally this will probably not be the case. Developers will
want to make sure no errors have been introduced since the baseline
before committing code. To improve DX SARB will look at diff between the
baseline commit and HEAD.

It is assumed the process will be something like this:

- developer edits code
- developer runs static analysis tool
- developer runs SARB
- developer removes any issues raised since the baseline
- once all post baseline issues are removed developer commits code

Hence the need for the diff to be taken against current state of code
rather than last commit.