### PR TITLE
Bump dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ composer-update-lowest: &composer-update-lowest
 composer-update: &composer-update
   run:
     name: Updrade to highest packages
-    command: composer update --prefer-lowest
+    command: composer update
 
 ci: &ci
   run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,3 @@
-image71: &image-71
-  docker:
-  - image: circleci/php:7.1-apache-stretch-node-browsers
-
 image72: &image-72
   docker:
   - image: circleci/php:7.2-apache-stretch-node-browsers
@@ -10,12 +6,6 @@ image72: &image-72
 image73: &image-73
   docker:
     - image: circleci/php:7.3-apache-stretch-node-browsers
-
-restore-71-cache: &restore-71-cache
-  restore_cache:
-      keys:
-      - v1-71-dependencies-{{ checksum "composer.lock" }}
-      - v1-71-dependencies-
 
 restore-72-cache: &restore-72-cache
   restore_cache:
@@ -28,12 +18,6 @@ restore-73-cache: &restore-73-cache
     keys:
       - v1-73-dependencies-{{ checksum "composer.lock" }}
       - v1-73-dependencies-
-
-save-71-cache: &save-71-cache
-  save_cache:
-    key: v1-71-dependencies-{{ checksum "composer.lock" }}
-    paths:
-    - vendor
 
 save-72-cache: &save-72-cache
   save_cache:
@@ -81,44 +65,6 @@ store-artifacts: &store-artifacts
 version: 2
 
 jobs:
-
-  build-71-lowest:
-    <<: *image-71
-
-    steps:
-      - checkout
-      - *restore-71-cache
-      - *composer-install
-      - *save-71-cache
-      - *composer-update-lowest
-      - *ci
-      - *store-test-results
-      - *store-artifacts
-
-  build-71-current:
-    <<: *image-71
-
-    steps:
-      - checkout
-      - *restore-71-cache
-      - *composer-install
-      - *save-71-cache
-      - *ci
-      - *store-test-results
-      - *store-artifacts
-
-  build-71-highest:
-    <<: *image-71
-
-    steps:
-      - checkout
-      - *restore-71-cache
-      - *composer-install
-      - *save-71-cache
-      - *composer-update
-      - *ci
-      - *store-test-results
-      - *store-artifacts
 
 
   build-72-lowest:
@@ -216,9 +162,6 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build-71-lowest
-      - build-71-current
-      - build-71-highest
       - build-72-lowest
       - build-72-current
       - build-72-highest

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,9 +21,9 @@ Vagrant.configure(2) do |config|
     wget -q https://packages.sury.org/php/apt.gpg -O- | apt-key add -
     echo "deb https://packages.sury.org/php/ stretch main" | tee /etc/apt/sources.list.d/php.list
     apt-get update
-    apt-get install -y php7.1-cli php7.1-xml php7.1-mbstring  php7.1-dev php-pear
+    apt-get install -y php7.2-cli php7.2-xml php7.2-mbstring  php7.2-dev php-pear
     pecl install ast-1.0.1
-    echo "extension=ast.so" > /etc/php/7.1/cli/conf.d//30-ast.ini
+    echo "extension=ast.so" > /etc/php/7.2/cli/conf.d/30-ast.ini
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
     sudo -iu vagrant /usr/local/bin/composer --working-dir=/vagrant install
   SHELL

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "sort-packages": true
   },
   "require": {
-    "php": ">=7.1 <8",
+    "php": ">=7.2 <8",
     "symfony/config": "^3.4 || ^4.0",
     "symfony/console": "^3.4 || ^4.0",
     "symfony/dependency-injection": "^3.4 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
   },
   "require": {
     "php": ">=7.2 <8",
-    "symfony/config": "^3.4 || ^4.0",
-    "symfony/console": "^3.4 || ^4.0",
-    "symfony/dependency-injection": "^3.4 || ^4.0",
-    "symfony/process": "^3.4 || ^4.0",
-    "symfony/yaml": "^3.4 || ^4.0",
+    "symfony/config": "^3.4 || ^4.0 || ^5.0",
+    "symfony/console": "^3.4 || ^4.0 || ^5.0",
+    "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
+    "symfony/process": "^3.4 || ^4.0 || ^5.0",
+    "symfony/yaml": "^3.4 || ^4.0 || ^5.0",
     "webmozart/assert": "^1.3",
     "webmozart/path-util": "^2.3"
   },
@@ -33,7 +33,7 @@
     "phpunit/phpunit": "^7.0",
     "sensiolabs-de/deptrac-shim": "^0.5.0",
     "sensiolabs/security-checker": "^5.0",
-    "symfony/filesystem": "^3.4 || ^4.0",
+    "symfony/filesystem": "^3.4 || ^4.0 || ^5.0",
     "vimeo/psalm": "^3.5.3"
   },
   "bin" : ["sarb"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e33dbd1312d0ba8422dff29bf5f4593",
+    "content-hash": "1bfca30ac5455f5ba0a8fa5a8ef2ebaf",
     "packages": [
         {
             "name": "psr/container",
@@ -57,32 +57,32 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.4.3",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "4d3979f54472637169080f802dc82197e21fdcce"
+                "reference": "7640c6704f56bf64045066bc5d93fd9d664baa63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/4d3979f54472637169080f802dc82197e21fdcce",
-                "reference": "4d3979f54472637169080f802dc82197e21fdcce",
+                "url": "https://api.github.com/repos/symfony/config/zipball/7640c6704f56bf64045066bc5d93fd9d664baa63",
+                "reference": "7640c6704f56bf64045066bc5d93fd9d664baa63",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/filesystem": "^3.4|^4.0|^5.0",
+                "php": "^7.2.5",
+                "symfony/filesystem": "^4.4|^5.0",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "symfony/finder": "<3.4"
+                "symfony/finder": "<4.4"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^3.4|^4.0|^5.0",
-                "symfony/finder": "^3.4|^4.0|^5.0",
-                "symfony/messenger": "^4.1|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/finder": "^4.4|^5.0",
+                "symfony/messenger": "^4.4|^5.0",
                 "symfony/service-contracts": "^1.1|^2",
-                "symfony/yaml": "^3.4|^4.0|^5.0"
+                "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -90,7 +90,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -117,7 +117,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-04T13:00:46+00:00"
+            "time": "2020-01-04T14:08:26+00:00"
         },
         {
             "name": "symfony/console",
@@ -197,37 +197,37 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v4.4.3",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "6faf589e1f6af78692aed3ab6b3c336c58d5d83c"
+                "reference": "5a56807650c7258bbcc4a15a020904958c70247e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/6faf589e1f6af78692aed3ab6b3c336c58d5d83c",
-                "reference": "6faf589e1f6af78692aed3ab6b3c336c58d5d83c",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5a56807650c7258bbcc4a15a020904958c70247e",
+                "reference": "5a56807650c7258bbcc4a15a020904958c70247e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "psr/container": "^1.0",
                 "symfony/service-contracts": "^1.1.6|^2"
             },
             "conflict": {
-                "symfony/config": "<4.3|>=5.0",
-                "symfony/finder": "<3.4",
-                "symfony/proxy-manager-bridge": "<3.4",
-                "symfony/yaml": "<3.4"
+                "symfony/config": "<5.0",
+                "symfony/finder": "<4.4",
+                "symfony/proxy-manager-bridge": "<4.4",
+                "symfony/yaml": "<4.4"
             },
             "provide": {
                 "psr/container-implementation": "1.0",
                 "symfony/service-implementation": "1.0"
             },
             "require-dev": {
-                "symfony/config": "^4.3",
-                "symfony/expression-language": "^3.4|^4.0|^5.0",
-                "symfony/yaml": "^3.4|^4.0|^5.0"
+                "symfony/config": "^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -239,7 +239,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -266,30 +266,30 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-21T07:39:36+00:00"
+            "time": "2020-01-21T08:40:24+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.4.3",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "266c9540b475f26122b61ef8b23dd9198f5d1cfd"
+                "reference": "3afadc0f57cd74f86379d073e694b0f2cda2a88c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/266c9540b475f26122b61ef8b23dd9198f5d1cfd",
-                "reference": "266c9540b475f26122b61ef8b23dd9198f5d1cfd",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3afadc0f57cd74f86379d073e694b0f2cda2a88c",
+                "reference": "3afadc0f57cd74f86379d073e694b0f2cda2a88c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -316,7 +316,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-21T08:20:44+00:00"
+            "time": "2020-01-21T08:40:24+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -495,25 +495,25 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.3",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36"
+                "reference": "f9ffd870f5ac01abec7b2b5e15f904ca9400ecd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f5697ab4cb14a5deed7473819e63141bf5352c36",
-                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f9ffd870f5ac01abec7b2b5e15f904ca9400ecd1",
+                "reference": "f9ffd870f5ac01abec7b2b5e15f904ca9400ecd1",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.2.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -540,7 +540,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-09T09:50:08+00:00"
+            "time": "2020-01-09T09:53:06+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -602,27 +602,27 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.4.3",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "cd014e425b3668220adb865f53bff64b3ad21767"
+                "reference": "69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/cd014e425b3668220adb865f53bff64b3ad21767",
-                "reference": "cd014e425b3668220adb865f53bff64b3ad21767",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a",
+                "reference": "69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "symfony/console": "<3.4"
+                "symfony/console": "<4.4"
             },
             "require-dev": {
-                "symfony/console": "^3.4|^4.0|^5.0"
+                "symfony/console": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -630,7 +630,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -657,7 +657,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-21T11:12:16+00:00"
+            "time": "2020-01-21T11:12:28+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "432cfc66e495ad242fbe93abc24e0991",
+    "content-hash": "7e33dbd1312d0ba8422dff29bf5f4593",
     "packages": [
         {
             "name": "psr/container",
@@ -57,32 +57,32 @@
         },
         {
             "name": "symfony/config",
-            "version": "v4.3.5",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "0acb26407a9e1a64a275142f0ae5e36436342720"
+                "reference": "4d3979f54472637169080f802dc82197e21fdcce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/0acb26407a9e1a64a275142f0ae5e36436342720",
-                "reference": "0acb26407a9e1a64a275142f0ae5e36436342720",
+                "url": "https://api.github.com/repos/symfony/config/zipball/4d3979f54472637169080f802dc82197e21fdcce",
+                "reference": "4d3979f54472637169080f802dc82197e21fdcce",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
-                "symfony/filesystem": "~3.4|~4.0",
+                "symfony/filesystem": "^3.4|^4.0|^5.0",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/finder": "<3.4"
             },
             "require-dev": {
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~3.4|~4.0",
-                "symfony/finder": "~3.4|~4.0",
-                "symfony/messenger": "~4.1",
-                "symfony/yaml": "~3.4|~4.0"
+                "symfony/event-dispatcher": "^3.4|^4.0|^5.0",
+                "symfony/finder": "^3.4|^4.0|^5.0",
+                "symfony/messenger": "^4.1|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -90,7 +90,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -117,31 +117,32 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-09-19T15:51:53+00:00"
+            "time": "2020-01-04T13:00:46+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.3.5",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "929ddf360d401b958f611d44e726094ab46a7369"
+                "reference": "e9ee09d087e2c88eaf6e5fc0f5c574f64d100e4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/929ddf360d401b958f611d44e726094ab46a7369",
-                "reference": "929ddf360d401b958f611d44e726094ab46a7369",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e9ee09d087e2c88eaf6e5fc0f5c574f64d100e4f",
+                "reference": "e9ee09d087e2c88eaf6e5fc0f5c574f64d100e4f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/service-contracts": "^1.1"
+                "symfony/service-contracts": "^1.1|^2"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<4.3",
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/lock": "<4.4",
                 "symfony/process": "<3.3"
             },
             "provide": {
@@ -149,12 +150,12 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
                 "symfony/event-dispatcher": "^4.3",
-                "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.4|~4.0",
-                "symfony/var-dumper": "^4.3"
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -165,7 +166,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -192,29 +193,29 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-07T12:36:49+00:00"
+            "time": "2020-01-10T21:54:01+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v4.3.5",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "e1e0762a814b957a1092bff75a550db49724d05b"
+                "reference": "6faf589e1f6af78692aed3ab6b3c336c58d5d83c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/e1e0762a814b957a1092bff75a550db49724d05b",
-                "reference": "e1e0762a814b957a1092bff75a550db49724d05b",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/6faf589e1f6af78692aed3ab6b3c336c58d5d83c",
+                "reference": "6faf589e1f6af78692aed3ab6b3c336c58d5d83c",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
                 "psr/container": "^1.0",
-                "symfony/service-contracts": "^1.1.6"
+                "symfony/service-contracts": "^1.1.6|^2"
             },
             "conflict": {
-                "symfony/config": "<4.3",
+                "symfony/config": "<4.3|>=5.0",
                 "symfony/finder": "<3.4",
                 "symfony/proxy-manager-bridge": "<3.4",
                 "symfony/yaml": "<3.4"
@@ -225,8 +226,8 @@
             },
             "require-dev": {
                 "symfony/config": "^4.3",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -238,7 +239,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -265,20 +266,20 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-02T12:58:58+00:00"
+            "time": "2020-01-21T07:39:36+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.3.5",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "9abbb7ef96a51f4d7e69627bc6f63307994e4263"
+                "reference": "266c9540b475f26122b61ef8b23dd9198f5d1cfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/9abbb7ef96a51f4d7e69627bc6f63307994e4263",
-                "reference": "9abbb7ef96a51f4d7e69627bc6f63307994e4263",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/266c9540b475f26122b61ef8b23dd9198f5d1cfd",
+                "reference": "266c9540b475f26122b61ef8b23dd9198f5d1cfd",
                 "shasum": ""
             },
             "require": {
@@ -288,7 +289,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -315,20 +316,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-20T14:07:54+00:00"
+            "time": "2020-01-21T08:20:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
                 "shasum": ""
             },
             "require": {
@@ -340,7 +341,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -373,20 +374,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
-                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
                 "shasum": ""
             },
             "require": {
@@ -398,7 +399,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -432,20 +433,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T14:18:11+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
+                "reference": "4b0e2222c55a25b4541305a053013d5647d3a25f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
-                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/4b0e2222c55a25b4541305a053013d5647d3a25f",
+                "reference": "4b0e2222c55a25b4541305a053013d5647d3a25f",
                 "shasum": ""
             },
             "require": {
@@ -454,7 +455,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -490,20 +491,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T16:25:15+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v4.3.5",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "50556892f3cc47d4200bfd1075314139c4c9ff4b"
+                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/50556892f3cc47d4200bfd1075314139c4c9ff4b",
-                "reference": "50556892f3cc47d4200bfd1075314139c4c9ff4b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5697ab4cb14a5deed7473819e63141bf5352c36",
+                "reference": "f5697ab4cb14a5deed7473819e63141bf5352c36",
                 "shasum": ""
             },
             "require": {
@@ -512,7 +513,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -539,24 +540,24 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-09-26T21:17:10+00:00"
+            "time": "2020-01-09T09:50:08+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.7",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "ffcde9615dc5bb4825b9f6aed07716f1f57faae0"
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ffcde9615dc5bb4825b9f6aed07716f1f57faae0",
-                "reference": "ffcde9615dc5bb4825b9f6aed07716f1f57faae0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/144c5e51266b281231e947b51223ba14acf1a749",
+                "reference": "144c5e51266b281231e947b51223ba14acf1a749",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "psr/container": "^1.0"
             },
             "suggest": {
@@ -565,7 +566,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -597,20 +598,20 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-09-17T11:12:18+00:00"
+            "time": "2019-11-18T17:27:11+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.3.5",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "41e16350a2a1c7383c4735aa2f9fce74cf3d1178"
+                "reference": "cd014e425b3668220adb865f53bff64b3ad21767"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/41e16350a2a1c7383c4735aa2f9fce74cf3d1178",
-                "reference": "41e16350a2a1c7383c4735aa2f9fce74cf3d1178",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/cd014e425b3668220adb865f53bff64b3ad21767",
+                "reference": "cd014e425b3668220adb865f53bff64b3ad21767",
                 "shasum": ""
             },
             "require": {
@@ -621,7 +622,7 @@
                 "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "~3.4|~4.0"
+                "symfony/console": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -629,7 +630,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -656,35 +657,33 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-09-11T15:41:19+00:00"
+            "time": "2020-01-21T11:12:16+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -706,7 +705,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-08-24T08:43:50+00:00"
+            "time": "2019-11-24T13:36:37+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -758,16 +757,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.3.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "5a294f13810844e3bdda28c0f352821d735ca9b3"
+                "reference": "13930a582947831bb66ff1aeac28672fd91c38ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/5a294f13810844e3bdda28c0f352821d735ca9b3",
-                "reference": "5a294f13810844e3bdda28c0f352821d735ca9b3",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/13930a582947831bb66ff1aeac28672fd91c38ea",
+                "reference": "13930a582947831bb66ff1aeac28672fd91c38ea",
                 "shasum": ""
             },
             "require": {
@@ -831,20 +830,20 @@
                 "non-blocking",
                 "promise"
             ],
-            "time": "2019-10-01T19:39:23+00:00"
+            "time": "2019-11-11T19:32:05+00:00"
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v1.7.0",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "3d457738751295b9bf6b15036578e7823919f724"
+                "reference": "9d8205686a004948475dc43f8a88d2fa5e75a113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/3d457738751295b9bf6b15036578e7823919f724",
-                "reference": "3d457738751295b9bf6b15036578e7823919f724",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/9d8205686a004948475dc43f8a88d2fa5e75a113",
+                "reference": "9d8205686a004948475dc43f8a88d2fa5e75a113",
                 "shasum": ""
             },
             "require": {
@@ -890,20 +889,20 @@
                 "non-blocking",
                 "stream"
             ],
-            "time": "2019-08-24T17:01:13+00:00"
+            "time": "2019-10-27T14:33:41+00:00"
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.2.4",
+            "version": "1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "10bb96592168a0f8e8f6dcde3532d9fa50b0b527"
+                "reference": "47fe531de31fca4a1b997f87308e7d7804348f7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/10bb96592168a0f8e8f6dcde3532d9fa50b0b527",
-                "reference": "10bb96592168a0f8e8f6dcde3532d9fa50b0b527",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/47fe531de31fca4a1b997f87308e7d7804348f7e",
+                "reference": "47fe531de31fca4a1b997f87308e7d7804348f7e",
                 "shasum": ""
             },
             "require": {
@@ -914,7 +913,7 @@
             "require-dev": {
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
                 "psr/log": "^1.0",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0"
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
             },
             "type": "library",
             "extra": {
@@ -946,28 +945,27 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2019-08-30T08:44:50+00:00"
+            "time": "2020-01-13T10:02:55+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e"
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
-                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
+                "url": "https://api.github.com/repos/composer/semver/zipball/c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
+                "reference": "c6bea70230ef4dd483e6bbcab6005f682ed3a8de",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+                "phpunit/phpunit": "^4.5 || ^5.0.5"
             },
             "type": "library",
             "extra": {
@@ -1008,28 +1006,28 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2019-03-19T17:25:45+00:00"
+            "time": "2020-01-13T12:06:48+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.3.3",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "46867cbf8ca9fb8d60c506895449eb799db1184f"
+                "reference": "cbe23383749496fe0f373345208b79568e4bc248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/46867cbf8ca9fb8d60c506895449eb799db1184f",
-                "reference": "46867cbf8ca9fb8d60c506895449eb799db1184f",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/cbe23383749496fe0f373345208b79568e4bc248",
+                "reference": "cbe23383749496fe0f373345208b79568e4bc248",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0",
+                "php": "^5.3.2 || ^7.0 || ^8.0",
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
             },
             "type": "library",
             "autoload": {
@@ -1047,12 +1045,12 @@
                     "email": "john-stevenson@blueyonder.co.uk"
                 }
             ],
-            "description": "Restarts a process without xdebug.",
+            "description": "Restarts a process without Xdebug.",
             "keywords": [
                 "Xdebug",
                 "performance"
             ],
-            "time": "2019-05-27T17:52:04+00:00"
+            "time": "2019-11-06T16:40:04+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -1124,16 +1122,16 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
-                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
@@ -1176,32 +1174,34 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-03-17T17:37:11+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "1.0.2",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8"
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/1febd6c3ef84253d7c815bed85fc622ad207a9f8",
-                "reference": "1febd6c3ef84253d7c815bed85fc622ad207a9f8",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
+                "reference": "5242d66dbeb21a30dd8a3e66bf7a73b66e05e1f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5"
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1215,12 +1215,12 @@
             ],
             "authors": [
                 {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
                     "name": "Guilherme Blanco",
                     "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Johannes Schmitt",
@@ -1236,7 +1236,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-06-08T11:03:04+00:00"
+            "time": "2019-10-30T14:39:59+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1328,16 +1328,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.15.3",
+            "version": "v2.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "705490b0f282f21017d73561e9498d2b622ee34c"
+                "reference": "c8afb599858876e95e8ebfcd97812d383fa23f02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/705490b0f282f21017d73561e9498d2b622ee34c",
-                "reference": "705490b0f282f21017d73561e9498d2b622ee34c",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/c8afb599858876e95e8ebfcd97812d383fa23f02",
+                "reference": "c8afb599858876e95e8ebfcd97812d383fa23f02",
                 "shasum": ""
             },
             "require": {
@@ -1348,15 +1348,15 @@
                 "ext-tokenizer": "*",
                 "php": "^5.6 || ^7.0",
                 "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.4.17 || ^4.1.6",
-                "symfony/event-dispatcher": "^3.0 || ^4.0",
-                "symfony/filesystem": "^3.0 || ^4.0",
-                "symfony/finder": "^3.0 || ^4.0",
-                "symfony/options-resolver": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
+                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
                 "symfony/polyfill-php70": "^1.0",
                 "symfony/polyfill-php72": "^1.4",
-                "symfony/process": "^3.0 || ^4.0",
-                "symfony/stopwatch": "^3.0 || ^4.0"
+                "symfony/process": "^3.0 || ^4.0 || ^5.0",
+                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
@@ -1369,8 +1369,8 @@
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
                 "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.1",
                 "phpunitgoodpractices/traits": "^1.8",
-                "symfony/phpunit-bridge": "^4.3",
-                "symfony/yaml": "^3.0 || ^4.0"
+                "symfony/phpunit-bridge": "^4.3 || ^5.0",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
                 "ext-mbstring": "For handling non-UTF8 characters in cache signature.",
@@ -1413,7 +1413,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2019-08-31T12:51:54+00:00"
+            "time": "2019-11-25T22:10:32+00:00"
         },
         {
             "name": "jakub-onderka/php-parallel-lint",
@@ -1561,16 +1561,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.3",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
-                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
@@ -1605,7 +1605,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2019-08-09T12:45:53+00:00"
+            "time": "2020-01-17T21:11:47+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1655,22 +1655,25 @@
         },
         {
             "name": "nette/bootstrap",
-            "version": "v3.0.0",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/bootstrap.git",
-                "reference": "e1075af05c211915e03e0c86542f3ba5433df4a3"
+                "reference": "b45a1e33b6a44beb307756522396551e5a9ff249"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/bootstrap/zipball/e1075af05c211915e03e0c86542f3ba5433df4a3",
-                "reference": "e1075af05c211915e03e0c86542f3ba5433df4a3",
+                "url": "https://api.github.com/repos/nette/bootstrap/zipball/b45a1e33b6a44beb307756522396551e5a9ff249",
+                "reference": "b45a1e33b6a44beb307756522396551e5a9ff249",
                 "shasum": ""
             },
             "require": {
                 "nette/di": "^3.0",
                 "nette/utils": "^3.0",
                 "php": ">=7.1"
+            },
+            "conflict": {
+                "tracy/tracy": "<2.6"
             },
             "require-dev": {
                 "latte/latte": "^2.2",
@@ -1724,29 +1727,29 @@
                 "configurator",
                 "nette"
             ],
-            "time": "2019-03-26T12:59:07+00:00"
+            "time": "2019-09-30T08:19:38+00:00"
         },
         {
             "name": "nette/di",
-            "version": "v3.0.1",
+            "version": "v3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/di.git",
-                "reference": "4aff517a1c6bb5c36fa09733d4cea089f529de6d"
+                "reference": "77d69061cbf8f9cfb7363dd983136f51213d3e41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/di/zipball/4aff517a1c6bb5c36fa09733d4cea089f529de6d",
-                "reference": "4aff517a1c6bb5c36fa09733d4cea089f529de6d",
+                "url": "https://api.github.com/repos/nette/di/zipball/77d69061cbf8f9cfb7363dd983136f51213d3e41",
+                "reference": "77d69061cbf8f9cfb7363dd983136f51213d3e41",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
                 "nette/neon": "^3.0",
-                "nette/php-generator": "^3.2.2",
+                "nette/php-generator": "^3.3.3",
                 "nette/robot-loader": "^3.2",
                 "nette/schema": "^1.0",
-                "nette/utils": "^3.0",
+                "nette/utils": "^3.1",
                 "php": ">=7.1"
             },
             "conflict": {
@@ -1754,6 +1757,7 @@
             },
             "require-dev": {
                 "nette/tester": "^2.2",
+                "phpstan/phpstan": "^0.12",
                 "tracy/tracy": "^2.3"
             },
             "type": "library",
@@ -1765,16 +1769,13 @@
             "autoload": {
                 "classmap": [
                     "src/"
-                ],
-                "files": [
-                    "src/compatibility.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
+                "GPL-2.0-only",
+                "GPL-3.0-only"
             ],
             "authors": [
                 {
@@ -1797,24 +1798,24 @@
                 "nette",
                 "static"
             ],
-            "time": "2019-08-07T12:11:33+00:00"
+            "time": "2020-01-20T12:14:54+00:00"
         },
         {
             "name": "nette/finder",
-            "version": "v2.5.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/finder.git",
-                "reference": "14164e1ddd69e9c5f627ff82a10874b3f5bba5fe"
+                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/finder/zipball/14164e1ddd69e9c5f627ff82a10874b3f5bba5fe",
-                "reference": "14164e1ddd69e9c5f627ff82a10874b3f5bba5fe",
+                "url": "https://api.github.com/repos/nette/finder/zipball/4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
+                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
                 "shasum": ""
             },
             "require": {
-                "nette/utils": "^2.4 || ~3.0.0",
+                "nette/utils": "^2.4 || ^3.0",
                 "php": ">=7.1"
             },
             "conflict": {
@@ -1822,6 +1823,7 @@
             },
             "require-dev": {
                 "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
                 "tracy/tracy": "^2.3"
             },
             "type": "library",
@@ -1859,35 +1861,36 @@
                 "iterator",
                 "nette"
             ],
-            "time": "2019-07-11T18:02:17+00:00"
+            "time": "2020-01-03T20:35:40+00:00"
         },
         {
             "name": "nette/neon",
-            "version": "v3.0.0",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/neon.git",
-                "reference": "cbff32059cbdd8720deccf9e9eace6ee516f02eb"
+                "reference": "0a18fc88801a14d66587932de133eeca01f7ce8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/neon/zipball/cbff32059cbdd8720deccf9e9eace6ee516f02eb",
-                "reference": "cbff32059cbdd8720deccf9e9eace6ee516f02eb",
+                "url": "https://api.github.com/repos/nette/neon/zipball/0a18fc88801a14d66587932de133eeca01f7ce8e",
+                "reference": "0a18fc88801a14d66587932de133eeca01f7ce8e",
                 "shasum": ""
             },
             "require": {
                 "ext-iconv": "*",
                 "ext-json": "*",
-                "php": ">=7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
                 "tracy/tracy": "^2.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -1911,7 +1914,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "? Nette NEON: encodes and decodes NEON file format.",
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",
@@ -1920,34 +1923,35 @@
                 "nette",
                 "yaml"
             ],
-            "time": "2019-02-05T21:30:40+00:00"
+            "time": "2019-12-27T04:00:04+00:00"
         },
         {
             "name": "nette/php-generator",
-            "version": "v3.2.3",
+            "version": "v3.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/php-generator.git",
-                "reference": "aea6e81437bb238e5f0e5b5ce06337433908e63b"
+                "reference": "a4ff22c91681fefaa774cf952a2b69c2ec9477c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/aea6e81437bb238e5f0e5b5ce06337433908e63b",
-                "reference": "aea6e81437bb238e5f0e5b5ce06337433908e63b",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/a4ff22c91681fefaa774cf952a2b69c2ec9477c1",
+                "reference": "a4ff22c91681fefaa774cf952a2b69c2ec9477c1",
                 "shasum": ""
             },
             "require": {
-                "nette/utils": "^2.4.2 || ~3.0.0",
+                "nette/utils": "^2.4.2 || ^3.0",
                 "php": ">=7.1"
             },
             "require-dev": {
                 "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
                 "tracy/tracy": "^2.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1958,8 +1962,8 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
+                "GPL-2.0-only",
+                "GPL-3.0-only"
             ],
             "authors": [
                 {
@@ -1971,7 +1975,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.3 features.",
+            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.4 features.",
             "homepage": "https://nette.org",
             "keywords": [
                 "code",
@@ -1979,30 +1983,31 @@
                 "php",
                 "scaffolding"
             ],
-            "time": "2019-07-05T13:01:56+00:00"
+            "time": "2020-01-20T11:40:42+00:00"
         },
         {
             "name": "nette/robot-loader",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/robot-loader.git",
-                "reference": "0712a0e39ae7956d6a94c0ab6ad41aa842544b5c"
+                "reference": "d2a100e1f5cab390c78bc88709abbc91249c3993"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/robot-loader/zipball/0712a0e39ae7956d6a94c0ab6ad41aa842544b5c",
-                "reference": "0712a0e39ae7956d6a94c0ab6ad41aa842544b5c",
+                "url": "https://api.github.com/repos/nette/robot-loader/zipball/d2a100e1f5cab390c78bc88709abbc91249c3993",
+                "reference": "d2a100e1f5cab390c78bc88709abbc91249c3993",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "nette/finder": "^2.5",
+                "nette/finder": "^2.5 || ^3.0",
                 "nette/utils": "^3.0",
                 "php": ">=7.1"
             },
             "require-dev": {
                 "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
                 "tracy/tracy": "^2.3"
             },
             "type": "library",
@@ -2032,7 +2037,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "? Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
+            "description": "🍀 Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
             "homepage": "https://nette.org",
             "keywords": [
                 "autoload",
@@ -2041,35 +2046,34 @@
                 "nette",
                 "trait"
             ],
-            "time": "2019-03-08T21:57:24+00:00"
+            "time": "2019-12-26T22:32:02+00:00"
         },
         {
             "name": "nette/schema",
-            "version": "v1.0.0",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "6241d8d4da39e825dd6cb5bfbe4242912f4d7e4d"
+                "reference": "febf71fb4052c824046f5a33f4f769a6e7fa0cb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/6241d8d4da39e825dd6cb5bfbe4242912f4d7e4d",
-                "reference": "6241d8d4da39e825dd6cb5bfbe4242912f4d7e4d",
+                "url": "https://api.github.com/repos/nette/schema/zipball/febf71fb4052c824046f5a33f4f769a6e7fa0cb4",
+                "reference": "febf71fb4052c824046f5a33f4f769a6e7fa0cb4",
                 "shasum": ""
             },
             "require": {
-                "nette/utils": "^3.0.1",
+                "nette/utils": "^3.1",
                 "php": ">=7.1"
             },
             "require-dev": {
                 "nette/tester": "^2.2",
+                "phpstan/phpstan-nette": "^0.12",
                 "tracy/tracy": "^2.3"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
+                "branch-alias": []
             },
             "autoload": {
                 "classmap": [
@@ -2098,20 +2102,20 @@
                 "config",
                 "nette"
             ],
-            "time": "2019-04-03T15:53:25+00:00"
+            "time": "2020-01-06T22:52:48+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v3.0.1",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bd961f49b211997202bda1d0fbc410905be370d4"
+                "reference": "d6cd63d77dd9a85c3a2fae707e1255e44c2bc182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bd961f49b211997202bda1d0fbc410905be370d4",
-                "reference": "bd961f49b211997202bda1d0fbc410905be370d4",
+                "url": "https://api.github.com/repos/nette/utils/zipball/d6cd63d77dd9a85c3a2fae707e1255e44c2bc182",
+                "reference": "d6cd63d77dd9a85c3a2fae707e1255e44c2bc182",
                 "shasum": ""
             },
             "require": {
@@ -2119,6 +2123,7 @@
             },
             "require-dev": {
                 "nette/tester": "~2.0",
+                "phpstan/phpstan": "^0.12",
                 "tracy/tracy": "^2.3"
             },
             "suggest": {
@@ -2127,12 +2132,13 @@
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
                 "ext-xml": "to use Strings::length() etc. when mbstring is not available"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -2174,20 +2180,20 @@
                 "utility",
                 "validation"
             ],
-            "time": "2019-03-22T01:00:30+00:00"
+            "time": "2020-01-03T18:13:31+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.2.4",
+            "version": "v4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "97e59c7a16464196a8b9c77c47df68e4a39a45c4"
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/97e59c7a16464196a8b9c77c47df68e4a39a45c4",
-                "reference": "97e59c7a16464196a8b9c77c47df68e4a39a45c4",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
                 "shasum": ""
             },
             "require": {
@@ -2195,6 +2201,7 @@
                 "php": ">=7.0"
             },
             "require-dev": {
+                "ircmaxell/php-yacc": "0.0.5",
                 "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
             },
             "bin": [
@@ -2203,7 +2210,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -2225,20 +2232,20 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-09-01T07:51:21+00:00"
+            "time": "2019-11-08T13:50:10+00:00"
         },
         {
             "name": "ocramius/package-versions",
-            "version": "1.4.0",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb"
+                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
-                "reference": "a4d4b60d0e60da2487bd21a2c6ac089f85570dbb",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
+                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
                 "shasum": ""
             },
             "require": {
@@ -2250,7 +2257,7 @@
                 "doctrine/coding-standard": "^5.0.1",
                 "ext-zip": "*",
                 "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.0.0"
+                "phpunit/phpunit": "^7.5.17"
             },
             "type": "composer-plugin",
             "extra": {
@@ -2275,7 +2282,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-02-21T12:16:21+00:00"
+            "time": "2019-11-15T16:17:10+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -2578,16 +2585,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.2",
+            "version": "4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
+                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
-                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
+                "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
                 "shasum": ""
             },
             "require": {
@@ -2599,6 +2606,7 @@
             "require-dev": {
                 "doctrine/instantiator": "^1.0.5",
                 "mockery/mockery": "^1.0",
+                "phpdocumentor/type-resolver": "0.4.*",
                 "phpunit/phpunit": "^6.4"
             },
             "type": "library",
@@ -2625,7 +2633,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-09-12T14:27:41+00:00"
+            "time": "2019-12-28T18:55:12+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2676,33 +2684,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.9.0",
+            "version": "v1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -2735,7 +2743,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-10-03T11:07:50+00:00"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -2786,16 +2794,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.11.16",
+            "version": "0.11.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "635cf20f3b92ce34ee94a8d2f282d62eb9dc6e1b"
+                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/635cf20f3b92ce34ee94a8d2f282d62eb9dc6e1b",
-                "reference": "635cf20f3b92ce34ee94a8d2f282d62eb9dc6e1b",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/63cc502f6957b7f74efbac444b4cf219dcadffd7",
+                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7",
                 "shasum": ""
             },
             "require": {
@@ -2803,6 +2811,7 @@
                 "jean85/pretty-package-versions": "^1.0.3",
                 "nette/bootstrap": "^2.4 || ^3.0",
                 "nette/di": "^2.4.7 || ^3.0",
+                "nette/neon": "^2.4.3 || ^3.0",
                 "nette/robot-loader": "^3.0.1",
                 "nette/schema": "^1.0",
                 "nette/utils": "^2.4.5 || ^3.0",
@@ -2856,7 +2865,7 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2019-09-17T11:19:51+00:00"
+            "time": "2019-10-22T20:20:22+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
@@ -3216,16 +3225,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.16",
+            "version": "7.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "316afa6888d2562e04aeb67ea7f2017a0eb41661"
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/316afa6888d2562e04aeb67ea7f2017a0eb41661",
-                "reference": "316afa6888d2562e04aeb67ea7f2017a0eb41661",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
                 "shasum": ""
             },
             "require": {
@@ -3296,20 +3305,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-09-14T09:08:39+00:00"
+            "time": "2020-01-08T08:45:45+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.1.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
                 "shasum": ""
             },
             "require": {
@@ -3318,7 +3327,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3343,7 +3352,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "time": "2019-11-01T11:05:21+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3512,16 +3521,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.2",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
-                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
@@ -3561,7 +3570,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-05-05T09:05:15+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4001,16 +4010,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.3.5",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "6229f58993e5a157f6096fc7145c0717d0be8807"
+                "reference": "9e3de195e5bc301704dd6915df55892f6dfc208b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6229f58993e5a157f6096fc7145c0717d0be8807",
-                "reference": "6229f58993e5a157f6096fc7145c0717d0be8807",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/9e3de195e5bc301704dd6915df55892f6dfc208b",
+                "reference": "9e3de195e5bc301704dd6915df55892f6dfc208b",
                 "shasum": ""
             },
             "require": {
@@ -4026,12 +4035,12 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.4|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/expression-language": "~3.4|~4.0",
-                "symfony/http-foundation": "^3.4|^4.0",
-                "symfony/service-contracts": "^1.1",
-                "symfony/stopwatch": "~3.4|~4.0"
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -4040,7 +4049,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -4067,7 +4076,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-10-01T16:40:32+00:00"
+            "time": "2020-01-10T21:54:01+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -4129,16 +4138,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.3.5",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5e575faa95548d0586f6bedaeabec259714e44d1"
+                "reference": "3a50be43515590faf812fbd7708200aabc327ec3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5e575faa95548d0586f6bedaeabec259714e44d1",
-                "reference": "5e575faa95548d0586f6bedaeabec259714e44d1",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/3a50be43515590faf812fbd7708200aabc327ec3",
+                "reference": "3a50be43515590faf812fbd7708200aabc327ec3",
                 "shasum": ""
             },
             "require": {
@@ -4147,7 +4156,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -4174,29 +4183,29 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-09-16T11:29:48+00:00"
+            "time": "2020-01-04T13:00:46+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.3.5",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "81c2e120522a42f623233968244baebd6b36cb6a"
+                "reference": "b1ab86ce52b0c0abe031367a173005a025e30e04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/81c2e120522a42f623233968244baebd6b36cb6a",
-                "reference": "81c2e120522a42f623233968244baebd6b36cb6a",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b1ab86ce52b0c0abe031367a173005a025e30e04",
+                "reference": "b1ab86ce52b0c0abe031367a173005a025e30e04",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.2.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4228,20 +4237,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2019-08-08T09:29:19+00:00"
+            "time": "2020-01-04T14:08:26+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "54b4c428a0054e254223797d2713c31e08610831"
+                "reference": "af23c7bb26a73b850840823662dda371484926c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/54b4c428a0054e254223797d2713c31e08610831",
-                "reference": "54b4c428a0054e254223797d2713c31e08610831",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/af23c7bb26a73b850840823662dda371484926c4",
+                "reference": "af23c7bb26a73b850840823662dda371484926c4",
                 "shasum": ""
             },
             "require": {
@@ -4251,7 +4260,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -4287,20 +4296,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "04ce3335667451138df4307d6a9b61565560199e"
+                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/04ce3335667451138df4307d6a9b61565560199e",
-                "reference": "04ce3335667451138df4307d6a9b61565560199e",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/66fea50f6cb37a35eea048d75a7d99a45b586038",
+                "reference": "66fea50f6cb37a35eea048d75a7d99a45b586038",
                 "shasum": ""
             },
             "require": {
@@ -4309,7 +4318,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -4342,30 +4351,30 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.3.5",
+            "version": "v5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "1e4ff456bd625be5032fac9be4294e60442e9b71"
+                "reference": "5d9add8034135b9a5f7b101d1e42c797e7f053e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/1e4ff456bd625be5032fac9be4294e60442e9b71",
-                "reference": "1e4ff456bd625be5032fac9be4294e60442e9b71",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5d9add8034135b9a5f7b101d1e42c797e7f053e4",
+                "reference": "5d9add8034135b9a5f7b101d1e42c797e7f053e4",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/service-contracts": "^1.0"
+                "php": "^7.2.5",
+                "symfony/service-contracts": "^1.0|^2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4392,7 +4401,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-07T11:52:19+00:00"
+            "time": "2020-01-04T14:08:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4436,31 +4445,36 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.5.3",
+            "version": "3.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "c3e781c4a06cbb17dc32068eb5d6de075f6babdc"
+                "reference": "389af1bfc739bfdff3f9e3dc7bd6499aee51a831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/c3e781c4a06cbb17dc32068eb5d6de075f6babdc",
-                "reference": "c3e781c4a06cbb17dc32068eb5d6de075f6babdc",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/389af1bfc739bfdff3f9e3dc7bd6499aee51a831",
+                "reference": "389af1bfc739bfdff3f9e3dc7bd6499aee51a831",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.1",
                 "amphp/byte-stream": "^1.5",
                 "composer/xdebug-handler": "^1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.4",
                 "netresearch/jsonmapper": "^1.0",
-                "nikic/php-parser": "^4.2",
+                "nikic/php-parser": "^4.3",
                 "ocramius/package-versions": "^1.2",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1.3",
                 "sebastian/diff": "^3.0",
-                "symfony/console": "^3.3||^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
                 "webmozart/glob": "^4.1",
                 "webmozart/path-util": "^2.3"
             },
@@ -4470,12 +4484,12 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
                 "ext-curl": "*",
-                "friendsofphp/php-cs-fixer": "^2.15",
                 "phpmyadmin/sql-parser": "^5.0",
+                "phpspec/prophecy": ">=1.9.0",
                 "phpunit/phpunit": "^7.5 || ^8.0",
                 "psalm/plugin-phpunit": "^0.6",
                 "slevomat/coding-standard": "^5.0",
-                "squizlabs/php_codesniffer": "3.4.0",
+                "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^4.3"
             },
             "suggest": {
@@ -4483,10 +4497,10 @@
             },
             "bin": [
                 "psalm",
-                "psalter",
                 "psalm-language-server",
                 "psalm-plugin",
-                "psalm-refactor"
+                "psalm-refactor",
+                "psalter"
             ],
             "type": "library",
             "extra": {
@@ -4502,7 +4516,8 @@
                     "Psalm\\": "src/Psalm"
                 },
                 "files": [
-                    "src/functions.php"
+                    "src/functions.php",
+                    "src/spl_object_id.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4520,7 +4535,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2019-09-27T13:22:06+00:00"
+            "time": "2020-01-15T03:46:19+00:00"
         },
         {
             "name": "webmozart/glob",
@@ -4576,7 +4591,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1 <8"
+        "php": ">=7.2 <8"
     },
     "platform-dev": []
 }

--- a/src/Domain/Analyser/BaseLineResultsRemover.php
+++ b/src/Domain/Analyser/BaseLineResultsRemover.php
@@ -23,12 +23,6 @@ class BaseLineResultsRemover
 {
     /**
      * Returns AnalysisResults stripping out those that appear in the BaseLine.
-     *
-     * @param AnalysisResults $latestAnalysisResults
-     * @param HistoryAnalyser $historyAnalyser
-     * @param AnalysisResults $baseLineAnalysisResults
-     *
-     * @return AnalysisResults
      */
     public function pruneBaseLine(
         AnalysisResults $latestAnalysisResults,

--- a/src/Domain/Analyser/internal/BaseLineResultsComparator.php
+++ b/src/Domain/Analyser/internal/BaseLineResultsComparator.php
@@ -32,8 +32,6 @@ class BaseLineResultsComparator
 
     /**
      * BaseLineResultsComparator constructor.
-     *
-     * @param AnalysisResults $baseLineAnalysisResults
      */
     public function __construct(AnalysisResults $baseLineAnalysisResults)
     {
@@ -51,11 +49,6 @@ class BaseLineResultsComparator
 
     /**
      * Returns true if an AnalysisResult of the same Type and Location exists in the BaseLine.
-     *
-     * @param Location $location
-     * @param Type $type
-     *
-     * @return bool
      */
     public function isInBaseLine(Location $location, Type $type): bool
     {

--- a/src/Domain/BaseLiner/BaseLineExporter.php
+++ b/src/Domain/BaseLiner/BaseLineExporter.php
@@ -30,8 +30,6 @@ class BaseLineExporter
 
     /**
      * BaseLineExporter constructor.
-     *
-     * @param FileWriter $fileWriter
      */
     public function __construct(FileWriter $fileWriter)
     {
@@ -40,9 +38,6 @@ class BaseLineExporter
 
     /**
      * Export BaseLine results to the given FileName.
-     *
-     * @param BaseLine $baseLine
-     * @param FileName $fileName
      *
      * @throws FileAccessException
      * @throws JsonParseException

--- a/src/Domain/BaseLiner/BaseLineImporter.php
+++ b/src/Domain/BaseLiner/BaseLineImporter.php
@@ -48,10 +48,6 @@ class BaseLineImporter
 
     /**
      * BaseLineImporter constructor.
-     *
-     * @param FileReader $fileReader
-     * @param ResultsParserLookupService $resultsParserLookupService
-     * @param HistoryFactoryLookupService $historyFactoryLookupService
      */
     public function __construct(
         FileReader $fileReader,
@@ -66,11 +62,7 @@ class BaseLineImporter
     /**
      * Imports baseline results.
      *
-     * @param FileName $fileName
-     *
      * @throws FileImportException
-     *
-     * @return BaseLine
      */
     public function import(FileName $fileName): BaseLine
     {

--- a/src/Domain/Common/BaseLine.php
+++ b/src/Domain/Common/BaseLine.php
@@ -47,11 +47,6 @@ class BaseLine
 
     /**
      * BaseLine constructor.
-     *
-     * @param HistoryFactory $historyFactory
-     * @param AnalysisResults $analysisResults
-     * @param ResultsParser $resultsParser
-     * @param HistoryMarker $historyMarker
      */
     public function __construct(
         HistoryFactory $historyFactory,
@@ -65,33 +60,21 @@ class BaseLine
         $this->historyMarker = $historyMarker;
     }
 
-    /**
-     * @return HistoryFactory
-     */
     public function getHistoryFactory(): HistoryFactory
     {
         return $this->historyFactory;
     }
 
-    /**
-     * @return AnalysisResults
-     */
     public function getAnalysisResults(): AnalysisResults
     {
         return $this->analysisResults;
     }
 
-    /**
-     * @return ResultsParser
-     */
     public function getResultsParser(): ResultsParser
     {
         return $this->resultsParser;
     }
 
-    /**
-     * @return HistoryMarker
-     */
     public function getHistoryMarker(): HistoryMarker
     {
         return $this->historyMarker;

--- a/src/Domain/Common/FileName.php
+++ b/src/Domain/Common/FileName.php
@@ -24,17 +24,12 @@ class FileName
 
     /**
      * FileName constructor.
-     *
-     * @param string $fileName
      */
     public function __construct(string $fileName)
     {
         $this->fileName = $fileName;
     }
 
-    /**
-     * @return string
-     */
     public function getFileName(): string
     {
         return $this->fileName;

--- a/src/Domain/Common/LineNumber.php
+++ b/src/Domain/Common/LineNumber.php
@@ -26,8 +26,6 @@ class LineNumber
 
     /**
      * LineNumber constructor.
-     *
-     * @param int $lineNumber
      */
     public function __construct(int $lineNumber)
     {
@@ -35,9 +33,6 @@ class LineNumber
         $this->lineNumber = $lineNumber;
     }
 
-    /**
-     * @return int
-     */
     public function getLineNumber(): int
     {
         return $this->lineNumber;

--- a/src/Domain/Common/Location.php
+++ b/src/Domain/Common/Location.php
@@ -26,9 +26,6 @@ class Location
 
     /**
      * Location constructor.
-     *
-     * @param FileName $fileName
-     * @param LineNumber $lineNumber
      */
     public function __construct(FileName $fileName, LineNumber $lineNumber)
     {
@@ -36,17 +33,11 @@ class Location
         $this->lineNumber = $lineNumber;
     }
 
-    /**
-     * @return FileName
-     */
     public function getFileName(): FileName
     {
         return $this->fileName;
     }
 
-    /**
-     * @return LineNumber
-     */
     public function getLineNumber(): LineNumber
     {
         return $this->lineNumber;
@@ -56,8 +47,6 @@ class Location
      * Returns true if $other refers to same location as this Location object.
      *
      * @param Location $other
-     *
-     * @return bool
      */
     public function isEqual(self $other): bool
     {
@@ -66,10 +55,6 @@ class Location
 
     /**
      * Used for ordering Locations, first by FileName then by line number.
-     *
-     * @param self $other
-     *
-     * @return int
      */
     public function compareTo(self $other): int
     {

--- a/src/Domain/Common/PreviousLocation.php
+++ b/src/Domain/Common/PreviousLocation.php
@@ -36,17 +36,11 @@ class PreviousLocation
         $this->location = $location;
     }
 
-    /**
-     * @return bool
-     */
     public function isNoPreviousLocation(): bool
     {
         return null === $this->location;
     }
 
-    /**
-     * @return Location
-     */
     public function getLocation(): Location
     {
         Assert::notNull($this->location, 'Trying to get Location when PreviousLocation is not set');

--- a/src/Domain/Common/ProjectRoot.php
+++ b/src/Domain/Common/ProjectRoot.php
@@ -26,9 +26,6 @@ class ProjectRoot
      * ProjectRoot constructor.
      *
      * If
-     *
-     * @param string $rootDirectory
-     * @param string $currentWorkingDirectory
      */
     public function __construct(string $rootDirectory, string $currentWorkingDirectory)
     {
@@ -42,11 +39,7 @@ class ProjectRoot
     /**
      * Returns path relative to project root.
      *
-     * @param string $fullPath
-     *
      * @throws InvalidPathException
-     *
-     * @return string
      */
     public function getPathRelativeToRootDirectory(string $fullPath): string
     {

--- a/src/Domain/Common/Type.php
+++ b/src/Domain/Common/Type.php
@@ -24,17 +24,12 @@ class Type
 
     /**
      * Type constructor.
-     *
-     * @param string $type
      */
     public function __construct(string $type)
     {
         $this->type = $type;
     }
 
-    /**
-     * @return string
-     */
     public function getType(): string
     {
         return $this->type;
@@ -44,8 +39,6 @@ class Type
      * Return true if equal.
      *
      * @param Type $type
-     *
-     * @return bool
      */
     public function isEqual(self $type): bool
     {

--- a/src/Domain/File/FileReader.php
+++ b/src/Domain/File/FileReader.php
@@ -21,11 +21,7 @@ class FileReader
     /**
      * Returns string containing contents of the file.
      *
-     * @param FileName $fileName
-     *
      * @throws FileAccessException
-     *
-     * @return string
      */
     public function readFile(FileName $fileName): string
     {
@@ -45,12 +41,8 @@ class FileReader
     /**
      * Returns array representing the contents of the file. Assumes the file must be JSON.
      *
-     * @param FileName $fileName
-     *
      * @throws JsonParseException
      * @throws FileAccessException
-     *
-     * @return array
      */
     public function readJsonFile(FileName $fileName): array
     {

--- a/src/Domain/File/FileWriter.php
+++ b/src/Domain/File/FileWriter.php
@@ -21,9 +21,6 @@ class FileWriter
     /**
      * Write $contents to the file.
      *
-     * @param FileName $fileName
-     * @param array $contents
-     *
      * @throws JsonParseException
      * @throws FileAccessException
      */
@@ -35,9 +32,6 @@ class FileWriter
 
     /**
      * Write $contents to the file.
-     *
-     * @param FileName $fileName
-     * @param string $contents
      *
      * @throws FileAccessException
      */

--- a/src/Domain/HistoryAnalyser/HistoryAnalyser.php
+++ b/src/Domain/HistoryAnalyser/HistoryAnalyser.php
@@ -22,10 +22,6 @@ interface HistoryAnalyser
 {
     /**
      * Return PreviousLocation (e.g. where it was in the baseline) for the current Location.
-     *
-     * @param Location $location
-     *
-     * @return PreviousLocation
      */
     public function getPreviousLocation(Location $location): PreviousLocation;
 }

--- a/src/Domain/HistoryAnalyser/HistoryFactory.php
+++ b/src/Domain/HistoryAnalyser/HistoryFactory.php
@@ -19,26 +19,17 @@ interface HistoryFactory
     /**
      * Creates a HistoryAnalyser by passing in HistoryMarker for when BaseLine was created.
      *
-     * @param HistoryMarker $baseLineHistoryMarker
-     * @param ProjectRoot $projectRoot
-     *
      * @throws HistoryAnalyserException
-     *
-     * @return HistoryAnalyser
      */
     public function newHistoryAnalyser(HistoryMarker $baseLineHistoryMarker, ProjectRoot $projectRoot): HistoryAnalyser;
 
     /**
      * Return factory for creating a HistoryMarker from a string representation of it.
-     *
-     * @return HistoryMarkerFactory
      */
     public function newHistoryMarkerFactory(): HistoryMarkerFactory;
 
     /**
      * Returns Identifier for HistoryMarker.
-     *
-     * @return string
      */
     public function getIdentifier(): string;
 }

--- a/src/Domain/HistoryAnalyser/HistoryFactoryLookupService.php
+++ b/src/Domain/HistoryAnalyser/HistoryFactoryLookupService.php
@@ -20,11 +20,7 @@ interface HistoryFactoryLookupService
     /**
      * Return HistoryFactory of the given name.
      *
-     * @param string $identifier
-     *
      * @throws InvalidHistoryFactoryException
-     *
-     * @return HistoryFactory
      */
     public function getHistoryFactory(string $identifier): HistoryFactory;
 }

--- a/src/Domain/HistoryAnalyser/HistoryMarker.php
+++ b/src/Domain/HistoryAnalyser/HistoryMarker.php
@@ -21,8 +21,6 @@ interface HistoryMarker
 {
     /**
      * Return the history maker as a string (to be stored in BaseLine).
-     *
-     * @return string
      */
     public function asString(): string;
 }

--- a/src/Domain/HistoryAnalyser/HistoryMarkerFactory.php
+++ b/src/Domain/HistoryAnalyser/HistoryMarkerFactory.php
@@ -18,19 +18,11 @@ interface HistoryMarkerFactory
 {
     /**
      * Create HistoryMarker based on the string version of it.
-     *
-     * @param string $historyMarkerAsString
-     *
-     * @return HistoryMarker
      */
     public function newHistoryMarker(string $historyMarkerAsString): HistoryMarker;
 
     /**
      * Return HistoryMarker representing current state of the code.
-     *
-     * @param ProjectRoot $projectRoot
-     *
-     * @return HistoryMarker
      */
     public function newCurrentHistoryMarker(ProjectRoot $projectRoot): HistoryMarker;
 }

--- a/src/Domain/ResultsParser/AnalysisResult.php
+++ b/src/Domain/ResultsParser/AnalysisResult.php
@@ -55,11 +55,6 @@ class AnalysisResult
      *
      * NOTE: $fullDetails should be a serialised version of the violation containing all the details that the
      * static analysis tool provided. It must be possible to reproduce the original violation from this string
-     *
-     * @param Location $location
-     * @param Type $type
-     * @param string $message
-     * @param string $fullDetails
      */
     public function __construct(Location $location, Type $type, string $message, string $fullDetails)
     {
@@ -69,25 +64,16 @@ class AnalysisResult
         $this->fullDetails = $fullDetails;
     }
 
-    /**
-     * @return Location
-     */
     public function getLocation(): Location
     {
         return $this->location;
     }
 
-    /**
-     * @return Type
-     */
     public function getType(): Type
     {
         return $this->type;
     }
 
-    /**
-     * @return string
-     */
     public function getFullDetails(): string
     {
         return $this->fullDetails;
@@ -100,11 +86,6 @@ class AnalysisResult
 
     /**
      * Return true if AnalysisResult matches given FileName, LineNumber and type.
-     *
-     * @param Location $location
-     * @param Type $type
-     *
-     * @return bool
      */
     public function isMatch(Location $location, Type $type): bool
     {
@@ -123,8 +104,6 @@ class AnalysisResult
     }
 
     /**
-     * @param array $array
-     *
      * @throws ArrayParseException
      *
      * @return AnalysisResult

--- a/src/Domain/ResultsParser/AnalysisResults.php
+++ b/src/Domain/ResultsParser/AnalysisResults.php
@@ -30,9 +30,6 @@ class AnalysisResults
         $this->analysisResults = [];
     }
 
-    /**
-     * @param AnalysisResult $analysisResult
-     */
     public function addAnalysisResult(AnalysisResult $analysisResult): void
     {
         $this->analysisResults[] = $analysisResult;
@@ -62,8 +59,6 @@ class AnalysisResults
 
     /**
      * Return as an array of arrays (ready for storing in a file).
-     *
-     * @return array
      */
     public function asArray(): array
     {
@@ -77,8 +72,6 @@ class AnalysisResults
 
     /**
      * Deserialises array representation to AnalysisResults.
-     *
-     * @param array $array
      *
      * @throws ArrayParseException
      *

--- a/src/Domain/ResultsParser/Exporter.php
+++ b/src/Domain/ResultsParser/Exporter.php
@@ -29,8 +29,6 @@ class Exporter
 
     /**
      * Exporter constructor.
-     *
-     * @param FileWriter $fileWriter
      */
     public function __construct(FileWriter $fileWriter)
     {
@@ -39,10 +37,6 @@ class Exporter
 
     /**
      * Exports AnalysisResults to the given $outputFile.
-     *
-     * @param AnalysisResults $analysisResults
-     * @param ResultsParser $resultsParser
-     * @param FileName $outputFile
      *
      * @throws JsonParseException
      * @throws FileAccessException

--- a/src/Domain/ResultsParser/Identifier.php
+++ b/src/Domain/ResultsParser/Identifier.php
@@ -16,8 +16,6 @@ interface Identifier
 {
     /**
      * Should be a short code (all identifiers must be unique).
-     *
-     * @return string
      */
     public function getCode(): string;
 
@@ -25,8 +23,6 @@ interface Identifier
      * Human readable description with plenty of detail.
      *
      * E.g. "Psalm results (JSON format)"
-     *
-     * @return string
      */
     public function getDescription(): string;
 }

--- a/src/Domain/ResultsParser/Importer.php
+++ b/src/Domain/ResultsParser/Importer.php
@@ -31,8 +31,6 @@ class Importer
 
     /**
      * Importer constructor.
-     *
-     * @param FileReader $fileReader
      */
     public function __construct(FileReader $fileReader)
     {
@@ -42,13 +40,7 @@ class Importer
     /**
      * Imports AnalysisResults from $fileName.
      *
-     * @param ResultsParser $resultsParser
-     * @param FileName $fileName
-     * @param ProjectRoot $projectRoot
-     *
      * @throws FileImportException
-     *
-     * @return AnalysisResults
      */
     public function importFromFile(
         ResultsParser $resultsParser,

--- a/src/Domain/ResultsParser/InvalidResultsParserException.php
+++ b/src/Domain/ResultsParser/InvalidResultsParserException.php
@@ -27,7 +27,6 @@ class InvalidResultsParserException extends SarbException
     /**
      * InvalidResultsParserException constructor.
      *
-     * @param string $invalidOption
      * @param Identifier[] $possibleValues
      */
     public function __construct(string $invalidOption, array $possibleValues)

--- a/src/Domain/ResultsParser/ResultsParser.php
+++ b/src/Domain/ResultsParser/ResultsParser.php
@@ -22,31 +22,20 @@ interface ResultsParser
     /**
      * Takes a string representation of the static analysis results and converts to AnalysisResults.
      *
-     * @param string $resultsAsString
-     * @param ProjectRoot $projectRoot
-     *
      * @throws ParseAtLocationException
      * @throws InvalidFileFormatException
-     *
-     * @return AnalysisResults
      */
     public function convertFromString(string $resultsAsString, ProjectRoot $projectRoot): AnalysisResults;
 
     /**
      * Create a string representation of the Analysis results (for persisting to a file).
      *
-     * @param AnalysisResults $analysisResults
-     *
      * @throws JsonParseException
-     *
-     * @return string
      */
     public function convertToString(AnalysisResults $analysisResults): string;
 
     /**
      * Returns the identifier of the Results Parser.
-     *
-     * @return Identifier
      */
     public function getIdentifier(): Identifier;
 
@@ -54,8 +43,6 @@ interface ResultsParser
      * Returns true if the ResultsParser has to guess the violation type.
      *
      * See docs/ViolationTypeClassificationGuessing.md
-     *
-     * @return bool
      */
     public function showTypeGuessingWarning(): bool;
 }

--- a/src/Domain/ResultsParser/ResultsParserLookupService.php
+++ b/src/Domain/ResultsParser/ResultsParserLookupService.php
@@ -17,11 +17,7 @@ interface ResultsParserLookupService
     /**
      * Returns ResultsParser of the given name.
      *
-     * @param string $name
-     *
      * @throws InvalidResultsParserException
-     *
-     * @return ResultsParser
      */
     public function getResultsParser(string $name): ResultsParser;
 }

--- a/src/Domain/ResultsParser/UnifiedDiffParser/FileMutation.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/FileMutation.php
@@ -34,8 +34,6 @@ class FileMutation
     /**
      * FileMutation constructor.
      *
-     * @param OriginalFileName|null $originalFileName
-     * @param NewFileName|null $newFileName
      * @param LineMutation[] $lineMutations
      */
     public function __construct(?OriginalFileName $originalFileName, ?NewFileName $newFileName, array $lineMutations)
@@ -48,9 +46,6 @@ class FileMutation
         $this->lineMutations = $lineMutations;
     }
 
-    /**
-     * @return OriginalFileName
-     */
     public function getOriginalFileName(): OriginalFileName
     {
         Assert::notNull($this->originalFileName);
@@ -58,9 +53,6 @@ class FileMutation
         return $this->originalFileName;
     }
 
-    /**
-     * @return NewFileName
-     */
     public function getNewFileName(): NewFileName
     {
         Assert::notNull($this->newFileName);

--- a/src/Domain/ResultsParser/UnifiedDiffParser/FileMutations.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/FileMutations.php
@@ -39,11 +39,6 @@ class FileMutations
 
     /**
      * Returns FileMutations for the given file name. Or null if there are no file mutations for that file in the diff.
-     *
-     *
-     * @param NewFileName $newFileName
-     *
-     * @return FileMutation|null
      */
     public function getFileMutation(NewFileName $newFileName): ?FileMutation
     {
@@ -66,8 +61,6 @@ class FileMutations
 
     /**
      * Returns number of FileMutations (only usecase is for testing).
-     *
-     * @return int
      */
     public function getCount(): int
     {

--- a/src/Domain/ResultsParser/UnifiedDiffParser/LineMutation.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/LineMutation.php
@@ -42,17 +42,11 @@ class LineMutation
         $this->originalLine = $originalLine;
     }
 
-    /**
-     * @return LineNumber|null
-     */
     public function getNewLine(): ?LineNumber
     {
         return $this->newLine;
     }
 
-    /**
-     * @return LineNumber|null
-     */
     public function getOriginalLine(): ?LineNumber
     {
         return $this->originalLine;
@@ -67,8 +61,6 @@ class LineMutation
      * Returns true if other LineMutation is the same.
      *
      * @param LineMutation|null $other
-     *
-     * @return bool
      */
     public function isEqual(?self $other): bool
     {

--- a/src/Domain/ResultsParser/UnifiedDiffParser/ParseException.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/ParseException.php
@@ -41,9 +41,6 @@ class ParseException extends HistoryAnalyserException
     /**
      * Create from DiffParseException.
      *
-     * @param string $location
-     * @param DiffParseException $e
-     *
      * @return ParseException
      */
     public static function fromDiffParseException(string $location, DiffParseException $e): self
@@ -53,10 +50,6 @@ class ParseException extends HistoryAnalyserException
 
     /**
      * ParseException constructor.
-     *
-     * @param string $location
-     * @param string $reason
-     * @param string $details
      */
     public function __construct(string $location, string $reason, string $details, ?Throwable $previous)
     {
@@ -67,25 +60,16 @@ class ParseException extends HistoryAnalyserException
         $this->details = $details;
     }
 
-    /**
-     * @return string
-     */
     public function getLocation(): string
     {
         return $this->location;
     }
 
-    /**
-     * @return string
-     */
     public function getReason(): string
     {
         return $this->reason;
     }
 
-    /**
-     * @return string
-     */
     public function getDetails(): string
     {
         return $this->details;

--- a/src/Domain/ResultsParser/UnifiedDiffParser/Parser.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/Parser.php
@@ -22,11 +22,7 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\UnifiedDif
 class Parser
 {
     /**
-     * @param string $diffAsString
-     *
      * @throws ParseException
-     *
-     * @return FileMutations
      */
     public function parseDiff(string $diffAsString): FileMutations
     {
@@ -54,8 +50,6 @@ class Parser
     }
 
     /**
-     * @param string $diffAsString
-     *
      * @return array<int,string>
      */
     private function getLines(string $diffAsString): array

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/ChangeHunkParserState.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/ChangeHunkParserState.php
@@ -39,9 +39,6 @@ class ChangeHunkParserState implements State
     /**
      * ChangeHunkParserState constructor.
      *
-     * @param FileMutationBuilder $fileMutationBuilder
-     * @param string $rangeInformationAsString
-     *
      * @throws DiffParseException
      */
     public function __construct(FileMutationBuilder $fileMutationBuilder, string $rangeInformationAsString)

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/DiffParseException.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/DiffParseException.php
@@ -50,17 +50,11 @@ class DiffParseException extends Exception
         $this->details = $details;
     }
 
-    /**
-     * @return string
-     */
     public function getReason(): string
     {
         return $this->reason;
     }
 
-    /**
-     * @return string
-     */
     public function getDetails(): string
     {
         return $this->details;

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/FileMutationBuilder.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/FileMutationBuilder.php
@@ -42,8 +42,6 @@ class FileMutationBuilder
 
     /**
      * FileMutationBuilder constructor.
-     *
-     * @param FileMutationsBuilder $fileMutationsBuilder
      */
     public function __construct(FileMutationsBuilder $fileMutationsBuilder)
     {

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindChangeHunkStartState.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindChangeHunkStartState.php
@@ -26,8 +26,6 @@ class FindChangeHunkStartState implements State
 
     /**
      * FindChangeHunkStartState constructor.
-     *
-     * @param FileMutationBuilder $fileMutationBuilder
      */
     public function __construct(FileMutationBuilder $fileMutationBuilder)
     {

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindFileDiffStartState.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindFileDiffStartState.php
@@ -21,8 +21,6 @@ class FindFileDiffStartState implements State
 
     /**
      * FindFileDiffStartState constructor.
-     *
-     * @param FileMutationsBuilder $fileMutationsBuilder
      */
     public function __construct(FileMutationsBuilder $fileMutationsBuilder)
     {

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindNewFileNameState.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindNewFileNameState.php
@@ -31,8 +31,6 @@ class FindNewFileNameState implements State
 
     /**
      * FindNewFileNameState constructor.
-     *
-     * @param FileMutationBuilder $fileMutationBuilder
      */
     public function __construct(FileMutationBuilder $fileMutationBuilder)
     {

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindOriginalFileNameState.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindOriginalFileNameState.php
@@ -27,8 +27,6 @@ class FindOriginalFileNameState implements State
 
     /**
      * FindOriginalFileNameState constructor.
-     *
-     * @param FileMutationsBuilder $fileMutationsBuilder
      */
     public function __construct(FileMutationsBuilder $fileMutationsBuilder)
     {

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindRenameToState.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/FindRenameToState.php
@@ -29,8 +29,6 @@ class FindRenameToState implements State
 
     /**
      * FindRenameToState constructor.
-     *
-     * @param FileMutationBuilder $fileMutationBuilder
      */
     public function __construct(FileMutationBuilder $fileMutationBuilder)
     {

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/RangeInformation.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/RangeInformation.php
@@ -39,8 +39,6 @@ class RangeInformation
     /**
      * RangeInformation constructor.
      *
-     * @param string $line
-     *
      * @throws DiffParseException
      */
     public function __construct(string $line)
@@ -68,33 +66,21 @@ class RangeInformation
         }
     }
 
-    /**
-     * @return int
-     */
     public function getOriginalFileStartLine(): int
     {
         return $this->originalFileStartLine;
     }
 
-    /**
-     * @return int
-     */
     public function getOriginalFileHunkSize(): int
     {
         return $this->originalFileHunkSize;
     }
 
-    /**
-     * @return int
-     */
     public function getNewFileStartLine(): int
     {
         return $this->newFileStartLine;
     }
 
-    /**
-     * @return int
-     */
     public function getNewFileHunkSize(): int
     {
         return $this->newFileHunkSize;

--- a/src/Domain/ResultsParser/UnifiedDiffParser/internal/State.php
+++ b/src/Domain/ResultsParser/UnifiedDiffParser/internal/State.php
@@ -13,8 +13,6 @@ namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\Unif
 interface State
 {
     /**
-     * @param string $line
-     *
      * @throws DiffParseException
      *
      * @return State

--- a/src/Domain/ResultsParserUtils/AbstractTextResultsParser.php
+++ b/src/Domain/ResultsParserUtils/AbstractTextResultsParser.php
@@ -49,12 +49,6 @@ abstract class AbstractTextResultsParser implements ResultsParser
 
     /**
      * AbstractTextResultsParser constructor.
-     *
-     * @param string $regEx
-     * @param string $fileNamePosition
-     * @param string $lineNumberPosition
-     * @param string $typePosition
-     * @param string $messagePosition
      */
     protected function __construct(
         string $regEx,
@@ -111,12 +105,7 @@ abstract class AbstractTextResultsParser implements ResultsParser
     }
 
     /**
-     * @param ProjectRoot $projectRoot
-     * @param string $line
-     *
      * @throws SarbException
-     *
-     * @return AnalysisResult|null
      */
     private function processLine(ProjectRoot $projectRoot, string $line): ?AnalysisResult
     {
@@ -157,8 +146,6 @@ abstract class AbstractTextResultsParser implements ResultsParser
      * Override if it is possible that you might not want to include this line in the results.
      *
      * @param string[] $matches
-     *
-     * @return bool
      */
     protected function includeLine(array $matches): bool
     {

--- a/src/Domain/Utils/ArrayUtils.php
+++ b/src/Domain/Utils/ArrayUtils.php
@@ -17,12 +17,7 @@ class ArrayUtils
     /**
      * Gets string value for given key in the array.
      *
-     * @param array $array
-     * @param string $key
-     *
      * @throws ArrayParseException
-     *
-     * @return string
      */
     public static function getStringValue(array $array, string $key): string
     {
@@ -36,12 +31,7 @@ class ArrayUtils
     /**
      * Gets int value for given key in the array.
      *
-     * @param array $array
-     * @param string $key
-     *
      * @throws ArrayParseException
-     *
-     * @return int
      */
     public static function getIntValue(array $array, string $key): int
     {
@@ -55,12 +45,7 @@ class ArrayUtils
     /**
      * Gets array value for given key in the array.
      *
-     * @param array $array
-     * @param string $key
-     *
      * @throws ArrayParseException
-     *
-     * @return array
      */
     public static function getArrayValue(array $array, string $key): array
     {
@@ -72,9 +57,6 @@ class ArrayUtils
     }
 
     /**
-     * @param array $array
-     * @param string $key
-     *
      * @throws ArrayParseException
      */
     private static function assertArrayKeyExists(array $array, string $key): void
@@ -106,12 +88,7 @@ class ArrayUtils
      *
      * $age would be the integer value 21.
      *
-     * @param array $array
-     * @param string $key
-     *
      * @throws ArrayParseException
-     *
-     * @return int
      */
     public static function getIntAsStringValue(array $array, string $key): int
     {

--- a/src/Domain/Utils/FqcnRemover.php
+++ b/src/Domain/Utils/FqcnRemover.php
@@ -12,10 +12,6 @@ class FqcnRemover
 {
     /**
      * Removes anything that looks like a FQCN from the string.
-     *
-     * @param string $raw
-     *
-     * @return string
      */
     public function removeRqcn(string $raw): string
     {

--- a/src/Domain/Utils/JsonUtils.php
+++ b/src/Domain/Utils/JsonUtils.php
@@ -17,11 +17,7 @@ class JsonUtils
     /**
      * Returns JSON string as an associative array representation.
      *
-     * @param string $jsonAsString
-     *
      * @throws JsonParseException
-     *
-     * @return array
      */
     public static function toArray(string $jsonAsString): array
     {
@@ -37,11 +33,7 @@ class JsonUtils
     /**
      * Converts array to a JSON representation in a string.
      *
-     * @param array $data
-     *
      * @throws JsonParseException
-     *
-     * @return string
      */
     public static function toString(array $data): string
     {

--- a/src/Domain/Utils/StringUtils.php
+++ b/src/Domain/Utils/StringUtils.php
@@ -18,11 +18,6 @@ class StringUtils
 {
     /**
      * Returns true if $haystack starts with $needle.
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @return bool
      */
     public static function startsWith(string $needle, string $haystack): bool
     {
@@ -31,11 +26,6 @@ class StringUtils
 
     /**
      * Remove $needle from start of $haystack.
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @return string
      */
     public static function removeFromStart(string $needle, string $haystack): string
     {
@@ -47,11 +37,6 @@ class StringUtils
 
     /**
      * Returns true if $haystack ends with $needle.
-     *
-     * @param string $needle
-     * @param string $haystack
-     *
-     * @return bool
      */
     public static function endsWith(string $needle, string $haystack): bool
     {
@@ -62,10 +47,6 @@ class StringUtils
 
     /**
      * Returns true if line is empty (or contains only white space).
-     *
-     * @param string $line
-     *
-     * @return bool
      */
     public static function isEmptyLine(string $line): bool
     {

--- a/src/Framework/Command/CreateBaseLineCommand.php
+++ b/src/Framework/Command/CreateBaseLineCommand.php
@@ -63,11 +63,6 @@ class CreateBaseLineCommand extends AbstractCommand
 
     /**
      * CreateBaseLineCommand constructor.
-     *
-     * @param ResultsParsersRegistry $resultsParsersRegistry
-     * @param HistoryFactoryLookupService $historyFactoryLookupService
-     * @param BaseLineExporter $exporter
-     * @param Importer $resultsImporter
      */
     public function __construct(
         ResultsParsersRegistry $resultsParsersRegistry,
@@ -129,11 +124,7 @@ class CreateBaseLineCommand extends AbstractCommand
     }
 
     /**
-     * @param InputInterface $input
-     *
      * @throws InvalidConfigException
-     *
-     * @return ResultsParser
      */
     private function getResultsParser(InputInterface $input, OutputInterface $output): ResultsParser
     {

--- a/src/Framework/Command/ListHistoryAnalysersCommand.php
+++ b/src/Framework/Command/ListHistoryAnalysersCommand.php
@@ -33,8 +33,6 @@ class ListHistoryAnalysersCommand extends Command
 
     /**
      * Constructor.
-     *
-     * @param HistoryFactoryRegistry $historyFactoryRegistry
      */
     public function __construct(HistoryFactoryRegistry $historyFactoryRegistry)
     {

--- a/src/Framework/Command/ListResultsParsesCommand.php
+++ b/src/Framework/Command/ListResultsParsesCommand.php
@@ -33,8 +33,6 @@ class ListResultsParsesCommand extends Command
 
     /**
      * Constructor.
-     *
-     * @param ResultsParsersRegistry $resultsParsersRegistry
      */
     public function __construct(ResultsParsersRegistry $resultsParsersRegistry)
     {

--- a/src/Framework/Command/RemoveBaseLineFromResultsCommand.php
+++ b/src/Framework/Command/RemoveBaseLineFromResultsCommand.php
@@ -61,11 +61,6 @@ class RemoveBaseLineFromResultsCommand extends AbstractCommand
 
     /**
      * CreateBaseLineCommand constructor.
-     *
-     * @param BaseLineResultsRemover $baseLineResultsRemover
-     * @param BaseLineImporter $baseLineImporter
-     * @param Importer $resultsImporter
-     * @param Exporter $resultsExporter
      */
     public function __construct(
         BaseLineResultsRemover $baseLineResultsRemover,
@@ -156,7 +151,6 @@ class RemoveBaseLineFromResultsCommand extends AbstractCommand
     }
 
     /**
-     * @param OutputInterface $output
      * @param AnalysisResult[] $analysisResults
      */
     private function displayErrorsSinceBaseLine(OutputInterface $output, array $analysisResults): void

--- a/src/Framework/Command/internal/AbstractCommand.php
+++ b/src/Framework/Command/internal/AbstractCommand.php
@@ -106,17 +106,9 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @param FileName $resultsFileName
-     * @param FileName $baseLineFileName
-     * @param ProjectRoot $projectRoot
-     *
      * @throws SarbException
      * @throws InvalidConfigException
      * @throws FileImportException
-     *
-     * @return int
      */
     abstract protected function executeHook(
         InputInterface $input,
@@ -127,12 +119,7 @@ abstract class AbstractCommand extends Command
     ): int;
 
     /**
-     * @param InputInterface $input
-     * @param string $argumentName
-     *
      * @throws InvalidConfigException
-     *
-     * @return FileName
      */
     protected function getFileName(InputInterface $input, string $argumentName): FileName
     {
@@ -140,12 +127,7 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param InputInterface $input
-     * @param string $argumentName
-     *
      * @throws InvalidConfigException
-     *
-     * @return string
      */
     protected function getArgument(InputInterface $input, string $argumentName): string
     {
@@ -153,12 +135,7 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param InputInterface $input
-     * @param string $optionName
-     *
      * @throws InvalidConfigException
-     *
-     * @return string|null
      */
     protected function getOption(InputInterface $input, string $optionName): ?string
     {
@@ -171,11 +148,8 @@ abstract class AbstractCommand extends Command
 
     /**
      * @param mixed $value
-     * @param string $errorMessageContext
      *
      * @throws InvalidConfigException
-     *
-     * @return string
      */
     private function asString($value, string $errorMessageContext): string
     {

--- a/src/Framework/Command/internal/InvalidConfigException.php
+++ b/src/Framework/Command/internal/InvalidConfigException.php
@@ -31,9 +31,6 @@ class InvalidConfigException extends Exception
 
     /**
      * InvalidConfigException constructor.
-     *
-     * @param string $option
-     * @param string $error
      */
     public function __construct(string $option, string $error)
     {
@@ -44,8 +41,6 @@ class InvalidConfigException extends Exception
 
     /**
      * Return problem with configuration.
-     *
-     * @return string
      */
     public function getProblem(): string
     {

--- a/src/Plugins/ExakatJsonResultsParser/ExakatJsonResultsParser.php
+++ b/src/Plugins/ExakatJsonResultsParser/ExakatJsonResultsParser.php
@@ -81,12 +81,7 @@ class ExakatJsonResultsParser implements ResultsParser
     /**
      * Converts from an array.
      *
-     * @param array $analysisResultsAsArray
-     * @param ProjectRoot $projectRoot
-     *
      * @throws ParseAtLocationException
-     *
-     * @return AnalysisResults
      */
     private function convertFromArray(array $analysisResultsAsArray, ProjectRoot $projectRoot): AnalysisResults
     {
@@ -110,13 +105,9 @@ class ExakatJsonResultsParser implements ResultsParser
     }
 
     /**
-     * @param array $analysisResultAsArray
-     *
      * @throws ArrayParseException
      * @throws JsonParseException
      * @throws InvalidPathException
-     *
-     * @return AnalysisResult
      */
     private function convertAnalysisResultFromArray(
         array $analysisResultAsArray,

--- a/src/Plugins/GitDiffHistoryAnalyser/DiffHistoryAnalyser.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/DiffHistoryAnalyser.php
@@ -29,8 +29,6 @@ class DiffHistoryAnalyser implements HistoryAnalyser
 
     /**
      * DiffHistoryAnalyser constructor.
-     *
-     * @param FileMutations $fileMutations
      */
     public function __construct(FileMutations $fileMutations)
     {
@@ -39,10 +37,6 @@ class DiffHistoryAnalyser implements HistoryAnalyser
 
     /**
      * Returns the location of the line number in the baseline (if it exists).
-     *
-     * @param Location $location
-     *
-     * @return PreviousLocation
      */
     public function getPreviousLocation(Location $location): PreviousLocation
     {

--- a/src/Plugins/GitDiffHistoryAnalyser/GitCommit.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/GitCommit.php
@@ -24,8 +24,6 @@ class GitCommit implements HistoryMarker
 
     /**
      * GitCommit constructor.
-     *
-     * @param string $gitSha
      */
     public function __construct(string $gitSha)
     {
@@ -43,10 +41,6 @@ class GitCommit implements HistoryMarker
 
     /**
      * Validates the string provided could be a valid git SHA.
-     *
-     * @param string $gitSha
-     *
-     * @return bool
      */
     public static function validateGitSha(string $gitSha): bool
     {

--- a/src/Plugins/GitDiffHistoryAnalyser/GitDiffHistoryFactory.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/GitDiffHistoryFactory.php
@@ -35,9 +35,6 @@ class GitDiffHistoryFactory implements HistoryFactory
 
     /**
      * GitDiffHistoryFactory constructor.
-     *
-     * @param GitWrapper $gitCliWrapper
-     * @param Parser $parser
      */
     public function __construct(GitWrapper $gitCliWrapper, Parser $parser)
     {

--- a/src/Plugins/GitDiffHistoryAnalyser/GitHistoryMarkerFactory.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/GitHistoryMarkerFactory.php
@@ -26,8 +26,6 @@ class GitHistoryMarkerFactory implements HistoryMarkerFactory
 
     /**
      * GitHistoryMarkerFactory constructor.
-     *
-     * @param GitWrapper $gitCliWrapper
      */
     public function __construct(GitWrapper $gitCliWrapper)
     {

--- a/src/Plugins/GitDiffHistoryAnalyser/internal/GitCliWrapper.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/internal/GitCliWrapper.php
@@ -49,9 +49,6 @@ class GitCliWrapper implements GitWrapper
 
     /**
      * @param string[] $gitCommand
-     * @param string $context
-     *
-     * @return string
      */
     private function runCommand(array $gitCommand, string $context): string
     {
@@ -76,7 +73,6 @@ class GitCliWrapper implements GitWrapper
 
     /**
      * @param string[] $arguments
-     * @param ProjectRoot $projectRoot
      *
      * @return string[]
      */

--- a/src/Plugins/GitDiffHistoryAnalyser/internal/GitWrapper.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/internal/GitWrapper.php
@@ -19,20 +19,11 @@ interface GitWrapper
 {
     /**
      * Returns a GitCommit representing the git HEAD or the project being analysed.
-     *
-     * @param ProjectRoot $projectRoot
-     *
-     * @return GitCommit
      */
     public function getCurrentSha(ProjectRoot $projectRoot): GitCommit;
 
     /**
      * Returns a diff (as a string) between the 2 commits.
-     *
-     * @param ProjectRoot $projectRoot
-     * @param GitCommit $originalCommit
-     *
-     * @return string
      */
     public function getGitDiff(ProjectRoot $projectRoot, GitCommit $originalCommit): string;
 }

--- a/src/Plugins/GitDiffHistoryAnalyser/internal/LineNumberMapper.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/internal/LineNumberMapper.php
@@ -49,17 +49,11 @@ class LineNumberMapper
         ++$this->newLineNumber;
     }
 
-    /**
-     * @return int
-     */
     public function getOriginalLineNumber(): int
     {
         return $this->originalLineNumber;
     }
 
-    /**
-     * @return int
-     */
     public function getNewLineNumber(): int
     {
         return $this->newLineNumber;

--- a/src/Plugins/GitDiffHistoryAnalyser/internal/OriginalLineNumberCalculator.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/internal/OriginalLineNumberCalculator.php
@@ -19,11 +19,6 @@ class OriginalLineNumberCalculator
 {
     /**
      * Returns original line number or null if the line was added in the mutation given the file mutations.
-     *
-     * @param FileMutation $fileMutation
-     * @param int $newLineNumber
-     *
-     * @return int|null
      */
     public static function calculateOriginalLineNumber(FileMutation $fileMutation, int $newLineNumber): ?int
     {

--- a/src/Plugins/PhanJsonResultsParser/PhanJsonResultsParser.php
+++ b/src/Plugins/PhanJsonResultsParser/PhanJsonResultsParser.php
@@ -87,11 +87,7 @@ class PhanJsonResultsParser implements ResultsParser
     /**
      * Converts from an array.
      *
-     * @param array $analysisResultsAsArray
-     *
      * @throws ParseAtLocationException
-     *
-     * @return AnalysisResults
      */
     private function convertFromArray(array $analysisResultsAsArray): AnalysisResults
     {
@@ -115,12 +111,8 @@ class PhanJsonResultsParser implements ResultsParser
     }
 
     /**
-     * @param array $analysisResultAsArray
-     *
      * @throws ArrayParseException
      * @throws JsonParseException
-     *
-     * @return AnalysisResult
      */
     private function convertAnalysisResultFromArray(array $analysisResultAsArray): AnalysisResult
     {

--- a/src/Plugins/PhpCodeSnifferFullResultsParser/PhpCodeSnifferFullResultsParser.php
+++ b/src/Plugins/PhpCodeSnifferFullResultsParser/PhpCodeSnifferFullResultsParser.php
@@ -41,13 +41,8 @@ class PhpCodeSnifferFullResultsParser implements ResultsParser
     /**
      * Takes a string representation of the static analysis results and converts to AnalysisResults.
      *
-     * @param string $resultsAsString
-     * @param ProjectRoot $projectRoot
-     *
      * @throws ParseAtLocationException
      * @throws InvalidFileFormatException
-     *
-     * @return AnalysisResults
      */
     public function convertFromString(string $resultsAsString, ProjectRoot $projectRoot): AnalysisResults
     {
@@ -64,11 +59,7 @@ class PhpCodeSnifferFullResultsParser implements ResultsParser
     /**
      * Create a string representation of the Analysis results (for persisting to a file).
      *
-     * @param AnalysisResults $analysisResults
-     *
      * @throws JsonParseException
-     *
-     * @return string
      */
     public function convertToString(AnalysisResults $analysisResults): string
     {

--- a/src/Plugins/PhpstanJsonResultsParser/PhpstanJsonResultsParser.php
+++ b/src/Plugins/PhpstanJsonResultsParser/PhpstanJsonResultsParser.php
@@ -52,8 +52,6 @@ class PhpstanJsonResultsParser implements ResultsParser
 
     /**
      * PhpstanJsonResultsParser constructor.
-     *
-     * @param FqcnRemover $fqcnRemover
      */
     public function __construct(FqcnRemover $fqcnRemover)
     {
@@ -130,12 +128,7 @@ class PhpstanJsonResultsParser implements ResultsParser
     /**
      * Converts from an array.
      *
-     * @param array $analysisResultsAsArray
-     * @param ProjectRoot $projectRoot
-     *
      * @throws ParseAtLocationException
-     *
-     * @return AnalysisResults
      */
     private function convertFromArray(array $analysisResultsAsArray, ProjectRoot $projectRoot): AnalysisResults
     {
@@ -175,14 +168,8 @@ class PhpstanJsonResultsParser implements ResultsParser
     }
 
     /**
-     * @param array $analysisResultAsArray
-     * @param FileName $fileName
-     * @param string $absoluteFilePath
-     *
      * @throws ArrayParseException
      * @throws JsonParseException
-     *
-     * @return AnalysisResult
      */
     private function convertAnalysisResultFromArray(
         array $analysisResultAsArray,

--- a/src/Plugins/PhpstanTextResultsParser/PhpstanTextResultsParser.php
+++ b/src/Plugins/PhpstanTextResultsParser/PhpstanTextResultsParser.php
@@ -30,8 +30,6 @@ class PhpstanTextResultsParser extends AbstractTextResultsParser
 
     /**
      * PsalmTextResultsParser constructor.
-     *
-     * @param FqcnRemover $fqcnRemover
      */
     public function __construct(FqcnRemover $fqcnRemover)
     {

--- a/src/Plugins/PsalmJsonResultsParser/PsalmJsonResultsParser.php
+++ b/src/Plugins/PsalmJsonResultsParser/PsalmJsonResultsParser.php
@@ -84,12 +84,7 @@ class PsalmJsonResultsParser implements ResultsParser
     /**
      * Converts from an array.
      *
-     * @param array $analysisResultsAsArray
-     * @param ProjectRoot $projectRoot
-     *
      * @throws ParseAtLocationException
-     *
-     * @return AnalysisResults
      */
     private function convertFromArray(array $analysisResultsAsArray, ProjectRoot $projectRoot): AnalysisResults
     {
@@ -116,13 +111,9 @@ class PsalmJsonResultsParser implements ResultsParser
     }
 
     /**
-     * @param array $analysisResultAsArray
-     *
      * @throws ArrayParseException
      * @throws JsonParseException
      * @throws InvalidPathException
-     *
-     * @return AnalysisResult
      */
     private function convertAnalysisResultFromArray(
         array $analysisResultAsArray,

--- a/src/Plugins/PsalmTextResultsParser/PsalmTextResultsParser.php
+++ b/src/Plugins/PsalmTextResultsParser/PsalmTextResultsParser.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\PsalmTextResultsParser;
 
-use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Type;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\Identifier;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParserUtils\AbstractTextResultsParser;
 

--- a/src/Plugins/SarbJsonResultsParser/SarbJsonResultsParser.php
+++ b/src/Plugins/SarbJsonResultsParser/SarbJsonResultsParser.php
@@ -82,12 +82,7 @@ class SarbJsonResultsParser implements ResultsParser
     /**
      * Converts from an array.
      *
-     * @param array $analysisResultsAsArray
-     * @param ProjectRoot $projectRoot
-     *
      * @throws ParseAtLocationException
-     *
-     * @return AnalysisResults
      */
     private function convertFromArray(array $analysisResultsAsArray, ProjectRoot $projectRoot): AnalysisResults
     {
@@ -111,13 +106,9 @@ class SarbJsonResultsParser implements ResultsParser
     }
 
     /**
-     * @param array $analysisResultAsArray
-     *
      * @throws JsonParseException
      * @throws InvalidPathException
      * @throws ArrayParseException
-     *
-     * @return AnalysisResult
      */
     private function convertAnalysisResultFromArray(
         array $analysisResultAsArray,

--- a/tests/Assertions/AssertGitCommit.php
+++ b/tests/Assertions/AssertGitCommit.php
@@ -12,9 +12,6 @@ trait AssertGitCommit
 {
     /**
      * Asserts HistoryMarker is of type GitCommit with the $expectedSha.
-     *
-     * @param string $expectedSha
-     * @param HistoryMarker $actual
      */
     private function assertGitCommit(string $expectedSha, HistoryMarker $actual): void
     {

--- a/tests/Helpers/AnalysisResultsAdderTrait.php
+++ b/tests/Helpers/AnalysisResultsAdderTrait.php
@@ -15,11 +15,6 @@ trait AnalysisResultsAdderTrait
 {
     /**
      * Adds an AnalysisResult (combination of fileName, lineNumber and type) to AnalysisResults.
-     *
-     * @param AnalysisResults $analysisResults
-     * @param string $fileName
-     * @param int $lineNumber
-     * @param string $type
      */
     private function addAnalysisResult(
         AnalysisResults $analysisResults,

--- a/tests/Helpers/ResourceLoaderTrait.php
+++ b/tests/Helpers/ResourceLoaderTrait.php
@@ -10,8 +10,6 @@ trait ResourceLoaderTrait
      * Returns contents of resource file.
      *
      * @param string $resourceName (file path relative to the tests/resources directory)
-     *
-     * @return string
      */
     private function getResource(string $resourceName): string
     {
@@ -22,8 +20,6 @@ trait ResourceLoaderTrait
      * Returns path of resource.
      *
      * @param string $resourceName (file path relative to the tests/resources directory)
-     *
-     * @return string
      */
     private function getPath(string $resourceName): string
     {

--- a/tests/Unit/Core/Analyser/StubHistoryFactory.php
+++ b/tests/Unit/Core/Analyser/StubHistoryFactory.php
@@ -23,8 +23,6 @@ class StubHistoryFactory implements HistoryFactory
 
     /**
      * StubHistoryFactory constructor.
-     *
-     * @param FileMutations $fileMutations
      */
     public function __construct(FileMutations $fileMutations)
     {

--- a/tests/Unit/Core/Analyser/internal/BaseLineResultsComparatorTest.php
+++ b/tests/Unit/Core/Analyser/internal/BaseLineResultsComparatorTest.php
@@ -94,11 +94,6 @@ class BaseLineResultsComparatorTest extends TestCase
 
     /**
      * @dataProvider dataProvider
-     *
-     * @param bool $expected
-     * @param string $fileName
-     * @param int $lineNumber
-     * @param string $type
      */
     public function testInBaseLine(bool $expected, string $fileName, int $lineNumber, string $type): void
     {

--- a/tests/Unit/Core/ResultsParser/UnifiedDiffParser/DiffParserTest.php
+++ b/tests/Unit/Core/ResultsParser/UnifiedDiffParser/DiffParserTest.php
@@ -231,9 +231,6 @@ class DiffParserTest extends TestCase
 
     /**
      * @dataProvider dataProvider
-     *
-     * @param string $inputFile
-     * @param array $expectedFileMutations
      */
     public function testDiffParser(string $inputFile, array $expectedFileMutations): void
     {

--- a/tests/Unit/Core/ResultsParser/UnifiedDiffParser/DiffParserTestSupport/ExpectedDiff.php
+++ b/tests/Unit/Core/ResultsParser/UnifiedDiffParser/DiffParserTestSupport/ExpectedDiff.php
@@ -23,8 +23,6 @@ class ExpectedDiff
 
     /**
      * ExpectedDiff constructor.
-     *
-     * @param string $diffFileName
      */
     private function __construct(string $diffFileName)
     {
@@ -39,9 +37,6 @@ class ExpectedDiff
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getDiffFileName(): string
     {
         return $this->diffFileName;

--- a/tests/Unit/Core/ResultsParser/UnifiedDiffParser/DiffParserTestSupport/ExpectedFileMutations.php
+++ b/tests/Unit/Core/ResultsParser/UnifiedDiffParser/DiffParserTestSupport/ExpectedFileMutations.php
@@ -96,33 +96,21 @@ class ExpectedFileMutations
         return $this;
     }
 
-    /**
-     * @return OriginalFileName
-     */
     public function getOriginalFileName(): OriginalFileName
     {
         return $this->originalFileName;
     }
 
-    /**
-     * @return NewFileName
-     */
     public function getNewFileName(): NewFileName
     {
         return $this->newFileName;
     }
 
-    /**
-     * @return bool
-     */
     public function isAddedFile(): bool
     {
         return $this->isAddedFile;
     }
 
-    /**
-     * @return bool
-     */
     public function isDeletedFile(): bool
     {
         return $this->isDeletedFile;

--- a/tests/Unit/Core/ResultsParser/UnifiedDiffParser/InvalidDiffParserTest.php
+++ b/tests/Unit/Core/ResultsParser/UnifiedDiffParser/InvalidDiffParserTest.php
@@ -38,10 +38,6 @@ class InvalidDiffParserTest extends TestCase
 
     /**
      * @dataProvider dataProvider
-     *
-     * @param string $inputFile
-     * @param string $location
-     * @param string $reason
      */
     public function testInvalidDiff(string $inputFile, string $location, string $reason): void
     {

--- a/tests/Unit/Core/ResultsParser/UnifiedDiffParser/LineMutationTest.php
+++ b/tests/Unit/Core/ResultsParser/UnifiedDiffParser/LineMutationTest.php
@@ -73,26 +73,17 @@ class LineMutationTest extends TestCase
 
     /**
      * @dataProvider equalDataProvider
-     *
-     * @param LineMutation $a
-     * @param LineMutation $b
      */
     public function testEqual(LineMutation $a, LineMutation $b): void
     {
         $this->assertTrue($a->isEqual($b));
     }
 
-    /**
-     * @return LineNumber
-     */
     private function getLineNumber1(): LineNumber
     {
         return new LineNumber(self::LINE_NUMBER_1);
     }
 
-    /**
-     * @return LineNumber
-     */
     private function getLineNumber2(): LineNumber
     {
         return new LineNumber(self::LINE_NUMBER_2);

--- a/tests/Unit/Core/ResultsParser/UnifiedDiffParser/internal/RangeInformationParserTest.php
+++ b/tests/Unit/Core/ResultsParser/UnifiedDiffParser/internal/RangeInformationParserTest.php
@@ -26,12 +26,6 @@ class RangeInformationParserTest extends TestCase
     /**
      * @dataProvider dataProvider
      *
-     * @param string $rangeInformationAsString
-     * @param int $originalStartLine
-     * @param int $originalHunkSize
-     * @param int $newStartLine
-     * @param int $newHunkSize
-     *
      * @throws DiffParseException
      */
     public function testHappyPath(
@@ -58,8 +52,6 @@ class RangeInformationParserTest extends TestCase
 
     /**
      * @dataProvider invalidDataProvider
-     *
-     * @param string $rangeInformationString
      */
     public function testInvalidData(string $rangeInformationString): void
     {

--- a/tests/Unit/Plugins/GitDiffHistoryAnalyser/GitCommitTest.php
+++ b/tests/Unit/Plugins/GitDiffHistoryAnalyser/GitCommitTest.php
@@ -27,7 +27,6 @@ class GitCommitTest extends TestCase
     }
 
     /**
-     * @param string $invalidCommit
      * @dataProvider invalidGitCommitDataProvider
      */
     public function testValidateInvalidGitCommit(string $invalidCommit): void
@@ -36,7 +35,6 @@ class GitCommitTest extends TestCase
     }
 
     /**
-     * @param string $invalidCommit
      * @dataProvider invalidGitCommitDataProvider
      */
     public function testInvalidGitCommit(string $invalidCommit): void
@@ -58,7 +56,6 @@ class GitCommitTest extends TestCase
     }
 
     /**
-     * @param string $commit
      * @dataProvider validGitCommitDataProvider
      */
     public function testValidateValidGitCommit(string $commit): void
@@ -67,7 +64,6 @@ class GitCommitTest extends TestCase
     }
 
     /**
-     * @param string $commit
      * @dataProvider validGitCommitDataProvider
      */
     public function testValidGitCommit(string $commit): void

--- a/tests/Unit/Plugins/GitDiffHistoryAnalyser/internal/OriginalLineNameCalculatorTest.php
+++ b/tests/Unit/Plugins/GitDiffHistoryAnalyser/internal/OriginalLineNameCalculatorTest.php
@@ -72,9 +72,6 @@ class OriginalLineNameCalculatorTest extends TestCase
 
     /**
      * @dataProvider dataProvider
-     *
-     * @param int $newLineNumber
-     * @param int|null $expectedOriginalLineNumber
      */
     public function testCalculateOriginalLine(int $newLineNumber, ?int $expectedOriginalLineNumber): void
     {

--- a/tests/resources/integration/commit1/src/Person.php
+++ b/tests/resources/integration/commit1/src/Person.php
@@ -11,17 +11,11 @@ class Person
      */
     private $name;
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
     public function setName(string $name): void
     {
         $this->name = $name;

--- a/tests/resources/integration/commit2/src/Person.php
+++ b/tests/resources/integration/commit2/src/Person.php
@@ -18,33 +18,21 @@ class Person
      */
     private $name;
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
     public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return int
-     */
     public function getAge(): int
     {
         return $this->age;
     }
 
-    /**
-     * @param int $age
-     */
     public function setAge(int $age): void
     {
         $this->age = $age;

--- a/tests/resources/integration/commit2/src/PersonFinder.php
+++ b/tests/resources/integration/commit2/src/PersonFinder.php
@@ -8,8 +8,6 @@ class PersonFinder
 {
     /**
      * @param Person[] $people
-     *
-     * @return array
      */
     public function findBobs(array $people): array
     {

--- a/tests/resources/integration/commit3/src/Person.php
+++ b/tests/resources/integration/commit3/src/Person.php
@@ -21,33 +21,21 @@ class Person
      */
     private $name;
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     */
     public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return int
-     */
     public function getAge(): int
     {
         return $this->age;
     }
 
-    /**
-     * @param int $age
-     */
     public function setAge(int $age): void
     {
         $this->age = $age;

--- a/tests/resources/integration/commit3/src/PersonFinder.php
+++ b/tests/resources/integration/commit3/src/PersonFinder.php
@@ -8,8 +8,6 @@ class PersonFinder
 {
     /**
      * @param Person[] $people
-     *
-     * @return array
      */
     public function findBobs(array $people): array
     {


### PR DESCRIPTION
Bump versions:

Min supported PHP version: 7.2
Works with Symfony 5

Fixes issues with CI where highest versions were not being checked.
