### PR TITLE
UPDATE list of exceptions for Psalm ignore

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,7 @@
     </issueHandlers>
 
     <ignoreExceptions>
+        <class name="Webmozart\Assert\InvalidArgumentException" />
         <class name="InvalidArgumentException" />
         <class name="LogicException" />
         <class name="Symfony\Component\Console\Exception\InvalidArgumentException" />


### PR DESCRIPTION
Webmozart have updated the exception thrown when an assert fails. 
These should be ignored, so the exception has been added to the list of exceptions that Psalm ignores. 