### PR TITLE
Remove webmozart/path-util usages

### DIFF
--- a/src/Domain/Common/AbsoluteFileName.php
+++ b/src/Domain/Common/AbsoluteFileName.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common;
 
-use Webmozart\PathUtil\Path;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\Path;
 
 class AbsoluteFileName extends FileName
 {

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\Path;
 
 // TODO this is getting a bit big. Split into multiple files.
 class EndToEndTest extends TestCase


### PR DESCRIPTION
```console
$ composer why webmozart/path-util
vimeo/psalm  4.13.1  requires  webmozart/path-util (^2.3)  

$ composer why vimeo/psalm
dave-liddament/sarb   dev-master  requires (for development)  vimeo/psalm (^4.13)
```