### PR TITLE
ADD support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+ARG PHP_VERSION
+FROM php:${PHP_VERSION}cli
+
+# install Composer
+COPY ./docker/composer.sh /root/
+
+RUN <<EOF
+set -eux;
+apt-get update;
+apt-get install -y  \
+    git  \
+    zip;
+rm -rf /var/lib/apt/lists/*;
+cd /root/;
+chmod 755 composer.sh;
+/root/composer.sh;
+mv /root/composer.phar /usr/local/bin/composer;
+rm /root/composer.sh;
+EOF
+
+# install Xdebug
+ARG XDEBUG_ENABLED=1
+
+RUN <<EOF
+if [ $XDEBUG_ENABLED -eq 1 ]; then
+    pecl install xdebug;
+    docker-php-ext-enable xdebug;
+fi
+EOF
+
+WORKDIR /app/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+services:
+  latest:
+    build:
+      args:
+        PHP_VERSION: ""
+    tty: true
+    volumes:
+      - .:/app/:delegated
+  php80:
+    build:
+      args:
+        PHP_VERSION: "8.0-"
+    extends:
+      service: latest
+  php81:
+    build:
+      args:
+        PHP_VERSION: "8.1-"
+    extends:
+      service: latest
+  php82:
+    build:
+      args:
+        PHP_VERSION: "8.2-"
+    extends:
+      service: latest
+  php83:
+    build:
+      args:
+        PHP_VERSION: "8.3-"
+    extends:
+      service: latest
+  php84:
+    build:
+      args:
+        PHP_VERSION: "8.4-rc-"
+        XDEBUG_ENABLED: 0
+    extends:
+      service: latest

--- a/docker/composer.sh
+++ b/docker/composer.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# copied from https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
I envisaged that the main development work would always happen in the `latest` container (which is built off the current released version of PHP) and then the others would be used to check compatibility.

You would need to use something like `docker compose build --pull` to move to the next version of PHP when it's released. It might be worth experimenting with the  [pull_policy](https://docs.docker.com/reference/compose-file/services/#pull_policy) property that has an `always` setting that will force that on every build.

I've added in a flag for Xdebug support (build arg `XDEBUG_ENABLED`) as there might not necessarily be PECL support for unreleased PHP versions, and it's only being used for analysing test coverage.