### PR TITLE
Add support for PHPStan error identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ NOTE: Checkout Psalm's built in [baseline feature](https://psalm.dev/docs/runnin
 vendor/bin/phpstan analyse --error-format=json | vendor/bin/sarb create --input-format="phpstan-json" phpstan.baseline
 vendor/bin/phpstan analyse --error-format=json | vendor/bin/sarb remove phpstan.baseline
 ```
+NOTE: PHPStan (from version 1.11) attaches an [error identifier](https://phpstan.org/error-identifiers) (e.g. `argument.type`)
+to each error. When identifiers are present SARB uses them as the violation type, which makes baselines robust against
+PHPStan rewording messages between releases. Baselines created before identifiers were available still work
+(SARB falls back to the old behaviour of [guessing the type](docs/ViolationTypeClassificationGuessing.md) from the message),
+but SARB will suggest regenerating the baseline so it uses the identifiers.
+If a baseline built from identifiers is used with results that contain none (e.g. after downgrading PHPStan),
+SARB stops with an error (exit code 17), since none of the baselined issues could be matched.
+
 NOTE: Checkout PHPStan's built in [baseline feature](https://phpstan.org/user-guide/baseline). Learn how [it differs from SARB](docs/SarbVsOtherBaseliningTechniques.md).
 
 #### [PHP Magic Number Detector](https://github.com/povils/phpmnd)

--- a/docs/HowSarbWorks.md
+++ b/docs/HowSarbWorks.md
@@ -20,6 +20,10 @@ For each violation it records:
  - type (e.g. PossibleNullValue)
  - serialised version of the violation (to include all other information about violation)
 
+NOTE: The type is ideally supplied by the static analysis tool (e.g. Psalm's issue type or
+PHPStan's [error identifier](https://phpstan.org/error-identifiers)). For tools that don't supply
+one, SARB [guesses the type from the violation message](ViolationTypeClassificationGuessing.md).
+
 
 Assume we have the following code that we run through [Psalm](https://getpsalm.org/r/23e7f1edb2) at it's most strict level.
 

--- a/docs/NewResultsParser.md
+++ b/docs/NewResultsParser.md
@@ -331,6 +331,18 @@ Finally each individual `AnalysisResult` should be added to the `AnalysisResults
 
 And that's it!
 
+#### Tools that used to guess the type
+
+`AnalysisResult`'s constructor takes an optional final argument `$legacyType`.
+This is only needed by parsers for tools that used to guess the violation type
+(see [Violation type classification guessing](ViolationTypeClassificationGuessing.md))
+and now provide a proper type (e.g. PHPStan's error identifiers).
+
+If the tool provides a proper type then pass it as the `Type` and pass the type as it
+would previously have been guessed as `$legacyType`. SARB uses the legacy type to match
+results against baselines created before the tool provided types, and to prompt the user
+to regenerate their baseline. See `PhpstanJsonResultsParser` for an example.
+
 
 #### Method: showTypeGuessingWarning
 

--- a/docs/ViolationTypeClassificationGuessing.md
+++ b/docs/ViolationTypeClassificationGuessing.md
@@ -50,3 +50,21 @@ of each violation it finds. If the tool you use doesn't then please
 encourage the authors (maybe by supplying a PR) to add this to the output from
 their tools.
 
+## PHPStan error identifiers
+
+PHPStan (from version 1.11) attaches an [error identifier](https://phpstan.org/error-identifiers)
+(e.g. `argument.type`) to each error. When identifiers are present SARB uses them as the
+violation type instead of guessing it from the message.
+
+Baselines created from results containing identifiers record this with a
+`typesFromToolIdentifiers` entry in the baseline file.
+
+For backwards compatibility, results that contain identifiers can still be matched against a
+baseline created before identifiers were available: alongside the identifier SARB keeps the type
+it would previously have guessed, and matches baseline entries against either. When this happens
+SARB recommends regenerating the baseline (with `sarb create`) so it uses the identifiers.
+
+If a baseline built from identifiers is used with results that contain none (e.g. the results
+were produced by an older version of PHPStan), then none of the baselined issues could be
+matched, so SARB stops with an error (exit code 17).
+

--- a/src/Domain/Analyser/BaseLineResultsRemover.php
+++ b/src/Domain/Analyser/BaseLineResultsRemover.php
@@ -52,6 +52,6 @@ final class BaseLineResultsRemover
         $location = $analysisResult->getLocation();
         $previousLocation = $historyAnalyser->getPreviousLocation($location->getRelativeFileName(), $location->getLineNumber());
 
-        return $baseLineResultsComparator->isInBaseLine($previousLocation, $analysisResult->getType());
+        return $baseLineResultsComparator->isInBaseLine($previousLocation, $analysisResult->getType(), $analysisResult->getLegacyType());
     }
 }

--- a/src/Domain/Analyser/internal/BaseLineResultsComparator.php
+++ b/src/Domain/Analyser/internal/BaseLineResultsComparator.php
@@ -46,9 +46,9 @@ final class BaseLineResultsComparator
     }
 
     /**
-     * Returns true if an AnalysisResult of the same Type and Location exists in the BaseLine.
+     * Returns true if an AnalysisResult of the same Type (or legacy Type) and Location exists in the BaseLine.
      */
-    public function isInBaseLine(PreviousLocation $previousLocation, Type $type): bool
+    public function isInBaseLine(PreviousLocation $previousLocation, Type $type, ?Type $legacyType = null): bool
     {
         // Analysis result refers to a Location not in the BaseLine, then this is not an historic analysis result.
         if ($previousLocation->isNoPreviousLocation()) {
@@ -63,7 +63,7 @@ final class BaseLineResultsComparator
         }
 
         foreach ($this->baseLine[$fileNameAsString] as $baseLineResult) {
-            if ($baseLineResult->isMatch($previousLocation, $type)) {
+            if ($baseLineResult->isMatch($previousLocation, $type, $legacyType)) {
                 return true;
             }
         }

--- a/src/Domain/BaseLiner/BaseLineAnalysisResult.php
+++ b/src/Domain/BaseLiner/BaseLineAnalysisResult.php
@@ -94,12 +94,19 @@ final class BaseLineAnalysisResult
 
     /**
      * Return true if this matches given FileName, LineNumber and type.
+     *
+     * If $legacyType is given then it is accepted as an alternative to $type. This allows results
+     * from tools that now provide type identifiers to match baselines created before identifiers
+     * were available.
      */
-    public function isMatch(PreviousLocation $location, Type $type): bool
+    public function isMatch(PreviousLocation $location, Type $type, ?Type $legacyType = null): bool
     {
-        return
-            $this->fileName->isEqual($location->getRelativeFileName())
-            && $this->lineNumber->isEqual($location->getLineNumber())
-            && $this->type->isEqual($type);
+        if (!$this->fileName->isEqual($location->getRelativeFileName())
+            || !$this->lineNumber->isEqual($location->getLineNumber())) {
+            return false;
+        }
+
+        return $this->type->isEqual($type)
+            || (null !== $legacyType && $this->type->isEqual($legacyType));
     }
 }

--- a/src/Domain/BaseLiner/BaseLineExporter.php
+++ b/src/Domain/BaseLiner/BaseLineExporter.php
@@ -36,8 +36,16 @@ final class BaseLineExporter
             BaseLine::HISTORY_ANALYSER => $baseLine->getHistoryFactory()->getIdentifier(),
             BaseLine::HISTORY_MARKER => $baseLine->getHistoryMarker()->asString(),
             BaseLine::RESULTS_PARSER => $baseLine->getResultsParser()->getIdentifier()->getCode(),
-            BaseLine::ANALYSIS_RESULTS => $baseLine->getAnalysisResults()->asArray(),
         ];
+
+        // Key omitted when no types came from tool identifiers, keeping the baseline identical to
+        // those produced by previous versions of SARB.
+        $typeIdentifiersUsageAsString = $baseLine->getTypeIdentifiersUsage()->asStringOrNull();
+        if (null !== $typeIdentifiersUsageAsString) {
+            $asArray[BaseLine::TYPES_FROM_TOOL_IDENTIFIERS] = $typeIdentifiersUsageAsString;
+        }
+
+        $asArray[BaseLine::ANALYSIS_RESULTS] = $baseLine->getAnalysisResults()->asArray();
 
         $this->fileWriter->writeArrayToFile($fileName, $asArray);
     }

--- a/src/Domain/BaseLiner/BaseLineImporter.php
+++ b/src/Domain/BaseLiner/BaseLineImporter.php
@@ -12,6 +12,7 @@ namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\BaseLiner;
 
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\BaseLine;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\BaseLineFileName;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\TypeIdentifiersUsage;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\File\FileAccessException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\File\FileReader;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\File\InvalidContentTypeException;
@@ -51,6 +52,9 @@ final class BaseLineImporter
             $analysisResultsAsArray = ArrayUtils::getArrayValue($baseLineData, BaseLine::ANALYSIS_RESULTS);
             $resultsParserName = ArrayUtils::getStringValue($baseLineData, BaseLine::RESULTS_PARSER);
             $historyAnalyserName = ArrayUtils::getStringValue($baseLineData, BaseLine::HISTORY_ANALYSER);
+            $typeIdentifiersUsage = TypeIdentifiersUsage::fromStringOrNull(
+                ArrayUtils::getOptionalStringValue($baseLineData, BaseLine::TYPES_FROM_TOOL_IDENTIFIERS),
+            );
 
             $resultsParser = $this->resultsParserLookupService->getResultsParser($resultsParserName);
             $historyFactory = $this->historyFactoryLookupService->getHistoryFactory($historyAnalyserName);
@@ -58,7 +62,7 @@ final class BaseLineImporter
             $historyMarker = $historyFactory->newHistoryMarkerFactory()->newHistoryMarker($historyMarkerAsString);
             $analysisResults = BaseLineAnalysisResults::fromArray($analysisResultsAsArray);
 
-            return new BaseLine($historyFactory, $analysisResults, $resultsParser, $historyMarker);
+            return new BaseLine($historyFactory, $analysisResults, $resultsParser, $historyMarker, $typeIdentifiersUsage);
         } catch (
             ArrayParseException|
             InvalidResultsParserException|

--- a/src/Domain/Common/BaseLine.php
+++ b/src/Domain/Common/BaseLine.php
@@ -21,7 +21,10 @@ final class BaseLine
     public const HISTORY_ANALYSER = 'historyAnalyser';
     public const ANALYSIS_RESULTS = 'analysisResults';
     public const RESULTS_PARSER = 'resultsParser';
+    public const TYPES_FROM_TOOL_IDENTIFIERS = 'typesFromToolIdentifiers';
     public const BASE_LINE = 'SARB BaseLine';
+
+    private TypeIdentifiersUsage $typeIdentifiersUsage;
 
     /**
      * BaseLine constructor.
@@ -31,7 +34,9 @@ final class BaseLine
         private BaseLineAnalysisResults $baseLineAnalysisResults,
         private ResultsParser $resultsParser,
         private HistoryMarker $historyMarker,
+        ?TypeIdentifiersUsage $typeIdentifiersUsage = null,
     ) {
+        $this->typeIdentifiersUsage = $typeIdentifiersUsage ?? TypeIdentifiersUsage::none();
     }
 
     public function getHistoryFactory(): HistoryFactory
@@ -52,5 +57,10 @@ final class BaseLine
     public function getHistoryMarker(): HistoryMarker
     {
         return $this->historyMarker;
+    }
+
+    public function getTypeIdentifiersUsage(): TypeIdentifiersUsage
+    {
+        return $this->typeIdentifiersUsage;
     }
 }

--- a/src/Domain/Common/TypeIdentifiersUsage.php
+++ b/src/Domain/Common/TypeIdentifiersUsage.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Static Analysis Results Baseliner (sarb).
+ *
+ * (c) Dave Liddament
+ *
+ * For the full copyright and licence information please view the LICENSE file distributed with this source code.
+ */
+
+namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common;
+
+/**
+ * Holds how many of the results' types came from identifiers provided by the static analysis tool
+ * (as opposed to types guessed from the violation message).
+ */
+final class TypeIdentifiersUsage
+{
+    private const NONE = 'none';
+    private const SOME = 'some';
+    private const ALL = 'all';
+
+    public static function none(): self
+    {
+        return new self(self::NONE);
+    }
+
+    public static function some(): self
+    {
+        return new self(self::SOME);
+    }
+
+    public static function all(): self
+    {
+        return new self(self::ALL);
+    }
+
+    /**
+     * NONE for null. Any unrecognised string is treated as SOME for forward compatibility.
+     */
+    public static function fromStringOrNull(?string $usage): self
+    {
+        if (null === $usage) {
+            return self::none();
+        }
+
+        if (self::ALL === $usage) {
+            return self::all();
+        }
+
+        return self::some();
+    }
+
+    private function __construct(
+        private string $usage,
+    ) {
+    }
+
+    /**
+     * Returns null for NONE (so the key can be omitted when serialising).
+     */
+    public function asStringOrNull(): ?string
+    {
+        return self::NONE === $this->usage ? null : $this->usage;
+    }
+
+    public function isFromToolIdentifiers(): bool
+    {
+        return self::NONE !== $this->usage;
+    }
+
+    public function isAllFromToolIdentifiers(): bool
+    {
+        return self::ALL === $this->usage;
+    }
+}

--- a/src/Domain/Creator/BaseLineCreator.php
+++ b/src/Domain/Creator/BaseLineCreator.php
@@ -30,7 +30,13 @@ final class BaseLineCreator implements BaseLineCreatorInterface
         $historyMarker = $historyFactory->newHistoryMarkerFactory()->newCurrentHistoryMarker($projectRoot, $forceBaselineCreation);
         $analysisResults = $this->analysisResultsImporter->import($resultsParser, $projectRoot, $analysisResultsAsString);
         $baseLineAnalysisResults = BaseLineAnalysisResults::fromAnalysisResults($analysisResults);
-        $baseline = new BaseLine($historyFactory, $baseLineAnalysisResults, $resultsParser, $historyMarker);
+        $baseline = new BaseLine(
+            $historyFactory,
+            $baseLineAnalysisResults,
+            $resultsParser,
+            $historyMarker,
+            $analysisResults->getTypeIdentifiersUsage(),
+        );
         $this->exporter->export($baseline, $baselineFile);
 
         return $baseline;

--- a/src/Domain/Pruner/InputMissingTypeIdentifiersException.php
+++ b/src/Domain/Pruner/InputMissingTypeIdentifiersException.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Static Analysis Results Baseliner (sarb).
+ *
+ * (c) Dave Liddament
+ *
+ * For the full copyright and licence information please view the LICENSE file distributed with this source code.
+ */
+
+namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Pruner;
+
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\SarbException;
+
+/**
+ * Thrown when the baseline was created from results containing type identifiers provided by the
+ * static analysis tool, but the supplied results contain none. None of the baseline results could
+ * be matched, so every baselined issue would be reported as new.
+ */
+final class InputMissingTypeIdentifiersException extends SarbException
+{
+    public static function baseLineBuiltFromTypeIdentifiers(): self
+    {
+        return new self(
+            'The baseline was created from results that contained type identifiers, '.
+            'but the supplied results contain none. '.
+            'This usually means the baseline was created with a newer version of the static analysis tool '.
+            '(e.g. PHPStan >= 1.11) than the one that produced these results. '.
+            'Either use the version of the tool the baseline was created with, or regenerate the baseline.',
+        );
+    }
+}

--- a/src/Domain/Pruner/PrunedResults.php
+++ b/src/Domain/Pruner/PrunedResults.php
@@ -28,4 +28,16 @@ final class PrunedResults
     {
         return $this->inputAnalysisResults;
     }
+
+    /**
+     * Returns true if the input results contain types from tool provided identifiers, but the
+     * baseline was created before the tool provided them (so matching fell back to legacy types).
+     * Regenerating the baseline would make it use the identifiers.
+     */
+    public function shouldRecommendRegeneratingBaseLine(): bool
+    {
+        return !$this->baseLine->getTypeIdentifiersUsage()->isFromToolIdentifiers()
+            && $this->baseLine->getAnalysisResults()->getCount() > 0
+            && $this->inputAnalysisResults->getTypeIdentifiersUsage()->isFromToolIdentifiers();
+    }
 }

--- a/src/Domain/Pruner/ResultsPruner.php
+++ b/src/Domain/Pruner/ResultsPruner.php
@@ -28,6 +28,7 @@ final class ResultsPruner implements ResultsPrunerInterface
      * @throws AnalysisResultsImportException
      * @throws HistoryAnalyserException
      * @throws ErrorReportedByStaticAnalysisTool
+     * @throws InputMissingTypeIdentifiersException
      */
     public function getPrunedResults(
         BaseLineFileName $baseLineFileName,
@@ -41,6 +42,13 @@ final class ResultsPruner implements ResultsPrunerInterface
 
         $historyAnalyser = $historyFactory->newHistoryAnalyser($baseLine->getHistoryMarker(), $projectRoot);
         $inputAnalysisResults = $this->analysisResultsImporter->import($resultsParser, $projectRoot, $analysisResults);
+
+        if ($baseLine->getTypeIdentifiersUsage()->isFromToolIdentifiers()
+            && !$inputAnalysisResults->hasNoIssues()
+            && !$inputAnalysisResults->getTypeIdentifiersUsage()->isFromToolIdentifiers()
+        ) {
+            throw InputMissingTypeIdentifiersException::baseLineBuiltFromTypeIdentifiers();
+        }
 
         $outputAnalysisResults = $this->baseLineResultsRemover->pruneBaseLine(
             $inputAnalysisResults,

--- a/src/Domain/Pruner/ResultsPrunerInterface.php
+++ b/src/Domain/Pruner/ResultsPrunerInterface.php
@@ -9,6 +9,9 @@ interface ResultsPrunerInterface
 {
     /**
      * Returns results with the baseline issues removed from them.
+     *
+     * @throws InputMissingTypeIdentifiersException if the baseline holds types from tool provided
+     *                                              identifiers but the supplied results contain none
      */
     public function getPrunedResults(
         BaseLineFileName $baseLineFileName,

--- a/src/Domain/ResultsParser/AnalysisResult.php
+++ b/src/Domain/ResultsParser/AnalysisResult.php
@@ -28,6 +28,11 @@ final class AnalysisResult
      * E.g. PHP-CS gives additional fields e.g. is_fixable. If this data needs to be shown to end user then
      * then a custom output formatter could be written to give all this additional information.
      *
+     * NOTE: $legacyType should only be set when $type came from an identifier provided by the static
+     * analysis tool. It holds the type as previous versions of the ResultsParser would have derived it
+     * (e.g. guessed from the violation message), and is used to match results against baselines created
+     * before the tool provided identifiers.
+     *
      * @param array<mixed> $fullDetails
      */
     public function __construct(
@@ -39,6 +44,7 @@ final class AnalysisResult
          */
         private array $fullDetails,
         private Severity $severity,
+        private ?Type $legacyType = null,
     ) {
     }
 
@@ -68,6 +74,11 @@ final class AnalysisResult
     public function getSeverity(): Severity
     {
         return $this->severity;
+    }
+
+    public function getLegacyType(): ?Type
+    {
+        return $this->legacyType;
     }
 
     public function asBaseLineAnalysisResult(): BaseLineAnalysisResult

--- a/src/Domain/ResultsParser/AnalysisResults.php
+++ b/src/Domain/ResultsParser/AnalysisResults.php
@@ -10,6 +10,8 @@
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser;
 
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\TypeIdentifiersUsage;
+
 /**
  * Holds all results from a run of the static analysis results.
  */
@@ -50,5 +52,25 @@ final class AnalysisResults
     public function hasNoIssues(): bool
     {
         return 0 === $this->getCount();
+    }
+
+    public function getTypeIdentifiersUsage(): TypeIdentifiersUsage
+    {
+        $resultsWithTypeIdentifierCount = 0;
+        foreach ($this->analysisResults as $analysisResult) {
+            if (null !== $analysisResult->getLegacyType()) {
+                ++$resultsWithTypeIdentifierCount;
+            }
+        }
+
+        if (0 === $resultsWithTypeIdentifierCount) {
+            return TypeIdentifiersUsage::none();
+        }
+
+        if ($resultsWithTypeIdentifierCount === $this->getCount()) {
+            return TypeIdentifiersUsage::all();
+        }
+
+        return TypeIdentifiersUsage::some();
     }
 }

--- a/src/Framework/Command/CreateBaseLineCommand.php
+++ b/src/Framework/Command/CreateBaseLineCommand.php
@@ -95,7 +95,7 @@ final class CreateBaseLineCommand extends Command
         try {
             $projectRoot = ProjectRootHelper::getProjectRoot($input);
             $historyFactory = $this->getHistoryFactory($input);
-            $resultsParser = $this->getResultsParser($input, $output);
+            $resultsParser = $this->getResultsParser($input);
             $baselineFile = BaseLineFileHelper::getBaselineFile($input);
             $force = CliConfigReader::getBooleanOption($input, self::FORCE);
             $analysisResultsAsString = CliConfigReader::getStdin($input);
@@ -108,6 +108,14 @@ final class CreateBaseLineCommand extends Command
                 $analysisResultsAsString,
                 $force,
             );
+
+            // No warning needed if every result's type came from an identifier provided by the tool.
+            if ($resultsParser->showTypeGuessingWarning()
+                && !$baseLine->getTypeIdentifiersUsage()->isAllFromToolIdentifiers()
+            ) {
+                $warning = '[%s] guesses the classification of violations. This means results might not be 100%% accurate. See %s for more details.';
+                $output->writeln(sprintf($warning, $resultsParser->getIdentifier()->getCode(), self::DOC_URL));
+            }
 
             $errorsInBaseLine = $baseLine->getAnalysisResults()->getCount();
             OutputWriter::writeToStdError($output, 'Baseline created', false);
@@ -122,22 +130,15 @@ final class CreateBaseLineCommand extends Command
     /**
      * @throws InvalidConfigException
      */
-    private function getResultsParser(InputInterface $input, OutputInterface $output): ResultsParser
+    private function getResultsParser(InputInterface $input): ResultsParser
     {
         $identifier = CliConfigReader::getOptionWithDefaultValue($input, self::INPUT_FORMAT);
 
         try {
-            $resultsParser = $this->resultsParserLookupService->getResultsParser($identifier);
+            return $this->resultsParserLookupService->getResultsParser($identifier);
         } catch (InvalidResultsParserException) {
             throw InvalidConfigException::invalidOptionValue(self::INPUT_FORMAT, $identifier, $this->resultsParserLookupService->getIdentifiers());
         }
-
-        if ($resultsParser->showTypeGuessingWarning()) {
-            $warning = '[%s] guesses the classification of violations. This means results might not be 100%% accurate. See %s for more details.';
-            $output->writeln(sprintf($warning, $identifier, self::DOC_URL));
-        }
-
-        return $resultsParser;
     }
 
     /**

--- a/src/Framework/Command/RemoveBaseLineFromResultsCommand.php
+++ b/src/Framework/Command/RemoveBaseLineFromResultsCommand.php
@@ -100,6 +100,14 @@ final class RemoveBaseLineFromResultsCommand extends Command
 
             $outputAnalysisResults = $prunedResults->getPrunedResults();
 
+            if ($prunedResults->shouldRecommendRegeneratingBaseLine()) {
+                OutputWriter::writeToStdError(
+                    $output,
+                    'The results now contain type identifiers provided by the static analysis tool, but the baseline was created before these were available (violation types were guessed from the messages). Regenerate the baseline so it uses the type identifiers.',
+                    false,
+                );
+            }
+
             OutputWriter::writeToStdError(
                 $output,
                 "Latest analysis issue count: {$prunedResults->getInputAnalysisResults()->getCount()}",

--- a/src/Framework/Command/internal/ErrorReporter.php
+++ b/src/Framework/Command/internal/ErrorReporter.php
@@ -6,6 +6,7 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\BaseLiner\BaseLineImport
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\SarbException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\File\FileAccessException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\HistoryAnalyser\HistoryAnalyserException;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Pruner\InputMissingTypeIdentifiersException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResultsImportException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\ErrorReportedByStaticAnalysisTool;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -40,6 +41,10 @@ final class ErrorReporter
             OutputWriter::writeToStdError($output, $e->getMessage(), true);
 
             return 16;
+        } catch (InputMissingTypeIdentifiersException $e) {
+            OutputWriter::writeToStdError($output, $e->getMessage(), true);
+
+            return 17;
         } catch (\Throwable $e) {
             // This should never happen. All exceptions should extend SarbException
             OutputWriter::writeToStdError($output, "Unexpected critical error: {$e->getMessage()}", true);

--- a/src/Plugins/OutputFormatters/GithubActionsOutputFormatter.php
+++ b/src/Plugins/OutputFormatters/GithubActionsOutputFormatter.php
@@ -17,10 +17,11 @@ final class GithubActionsOutputFormatter implements OutputFormatter
 
             $message = str_replace("\n", '%0A', $analysisResult->getMessage());
             $lines[] = sprintf(
-                '::%s file=%s,line=%d::%s',
+                '::%s file=%s,line=%d,title=%s::%s',
                 $analysisResult->getSeverity()->getSeverity(),
                 $location->getRelativeFileName()->getFileName(),
                 $location->getLineNumber()->getLineNumber(),
+                $this->escapeProperty($analysisResult->getType()->getType()),
                 $message,
             );
         }
@@ -31,5 +32,18 @@ final class GithubActionsOutputFormatter implements OutputFormatter
     public function getIdentifier(): string
     {
         return 'github';
+    }
+
+    /**
+     * Escapes a workflow command property value. Unlike the message, property values must also
+     * have ':' and ',' escaped, otherwise they would terminate the property list.
+     */
+    private function escapeProperty(string $value): string
+    {
+        return str_replace(
+            ['%', "\r", "\n", ':', ','],
+            ['%25', '%0D', '%0A', '%3A', '%2C'],
+            $value,
+        );
     }
 }

--- a/src/Plugins/OutputFormatters/TableOutputFormatter.php
+++ b/src/Plugins/OutputFormatters/TableOutputFormatter.php
@@ -41,6 +41,7 @@ final class TableOutputFormatter implements OutputFormatter
         /** @var string[] $headings */
         $headings = [
             'Line',
+            'Type',
             'Description',
         ];
 
@@ -71,6 +72,7 @@ final class TableOutputFormatter implements OutputFormatter
             Assert::notNull($currentTable, 'No Table object');
             $currentTable->addRow([
                 $analysisResult->getLocation()->getLineNumber()->getLineNumber(),
+                $analysisResult->getType()->getType(),
                 $prefix.$analysisResult->getMessage(),
             ]);
         }

--- a/src/Plugins/ResultsParsers/PhpstanJsonResultsParser/PhpstanJsonResultsParser.php
+++ b/src/Plugins/ResultsParsers/PhpstanJsonResultsParser/PhpstanJsonResultsParser.php
@@ -38,7 +38,8 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\ParseAtLocationExc
 final class PhpstanJsonResultsParser implements ResultsParser
 {
     private const LINE = 'line';
-    private const TYPE = 'message';
+    private const MESSAGE = 'message';
+    private const IDENTIFIER = 'identifier';
     private const FILES = 'files';
     private const MESSAGES = 'messages';
     private const ERRORS = 'errors';
@@ -120,8 +121,19 @@ final class PhpstanJsonResultsParser implements ResultsParser
             $lineAsInt = 0;
         }
 
-        $rawType = ArrayUtils::getStringValue($analysisResultAsArray, self::TYPE);
-        $type = $this->fqcnRemover->removeRqcn($rawType);
+        $message = ArrayUtils::getStringValue($analysisResultAsArray, self::MESSAGE);
+        $identifier = ArrayUtils::getOptionalStringValue($analysisResultAsArray, self::IDENTIFIER);
+        $guessedType = $this->fqcnRemover->removeRqcn($message);
+
+        if (null !== $identifier && '' !== $identifier) {
+            // PHPStan supplies an identifier (e.g. argument.type). Use it as the type. Keep the guessed
+            // type so results can be matched against baselines created before identifiers were used.
+            $type = new Type($identifier);
+            $legacyType = new Type($guessedType);
+        } else {
+            $type = new Type($guessedType);
+            $legacyType = null;
+        }
 
         $location = Location::fromAbsoluteFileName(
             $absoluteFileName,
@@ -131,10 +143,11 @@ final class PhpstanJsonResultsParser implements ResultsParser
 
         return new AnalysisResult(
             $location,
-            new Type($type),
-            $rawType,
+            $type,
+            $message,
             $analysisResultAsArray,
             Severity::error(),
+            $legacyType,
         );
     }
 

--- a/tests/Helpers/AnalysisResultsAdderTrait.php
+++ b/tests/Helpers/AnalysisResultsAdderTrait.php
@@ -23,8 +23,9 @@ trait AnalysisResultsAdderTrait
         int $lineNumber,
         string $type,
         Severity $severity,
+        ?string $legacyType = null,
     ): void {
-        $analysisResult = $this->buildAnalysisResult($projectRoot, $absoluteFileName, $lineNumber, $type, $severity);
+        $analysisResult = $this->buildAnalysisResult($projectRoot, $absoluteFileName, $lineNumber, $type, $severity, $legacyType);
         $analysisResultsBuilder->addAnalysisResult($analysisResult);
     }
 
@@ -34,6 +35,7 @@ trait AnalysisResultsAdderTrait
         int $lineNumber,
         string $type,
         Severity $severity,
+        ?string $legacyType = null,
     ): AnalysisResult {
         $message = "message-$type";
 
@@ -43,6 +45,13 @@ trait AnalysisResultsAdderTrait
             new LineNumber($lineNumber),
         );
 
-        return new AnalysisResult($location, new Type($type), $message, [], $severity);
+        return new AnalysisResult(
+            $location,
+            new Type($type),
+            $message,
+            [],
+            $severity,
+            null === $legacyType ? null : new Type($legacyType),
+        );
     }
 }

--- a/tests/Integration/PhpstanIdentifiersEndToEndTest.php
+++ b/tests/Integration/PhpstanIdentifiersEndToEndTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Integration;
+
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\Path;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\StringUtils;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Command\CreateBaseLineCommand;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Command\RemoveBaseLineFromResultsCommand;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Container\Container;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\GitDiffHistoryAnalyser\internal\GitCliWrapper;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Helpers\ResourceLoaderTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * End to end tests of the 4 combinations of baseline and analysis results, with and without
+ * PHPStan error identifiers (which SARB uses as the violation type when supplied).
+ */
+final class PhpstanIdentifiersEndToEndTest extends TestCase
+{
+    use ResourceLoaderTrait;
+    use TestDirectoryTrait;
+
+    private const COMMIT_1_DIRECTORY = 'integration/commit1';
+
+    private const RESULTS_WITH_IDENTIFIERS = 'phpstan-identifiers.json';
+    private const RESULTS_WITH_IDENTIFIERS_REWORDED_PLUS_NEW_ISSUE = 'phpstan-identifiers-reworded-plus-new.json';
+    private const RESULTS_WITH_IDENTIFIERS_PLUS_NEW_ISSUE = 'phpstan-identifiers-plus-new.json';
+    private const RESULTS_WITHOUT_IDENTIFIERS = 'phpstan-no-identifiers.json';
+
+    private const TYPES_FROM_TOOL_IDENTIFIERS_KEY = 'typesFromToolIdentifiers';
+    private const TYPE_GUESSING_WARNING = 'guesses the classification of violations';
+    private const REGENERATE_RECOMMENDATION = 'Regenerate the baseline';
+    private const NEW_ISSUE_IDENTIFIER = 'method.notFound';
+
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var GitCliWrapper
+     */
+    private $gitWrapper;
+
+    /**
+     * @var ProjectRoot
+     */
+    private $projectRoot;
+
+    /**
+     * @var Application
+     */
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->fileSystem = new Filesystem();
+        $this->gitWrapper = new GitCliWrapper();
+        $container = new Container();
+        $this->application = $container->getApplication();
+    }
+
+    public function testIdentifierBaseLineWithIdentifierResults(): void
+    {
+        $this->setUpProjectWithCommit1();
+
+        $createOutput = $this->runCreateBaseLineCommand(self::RESULTS_WITH_IDENTIFIERS);
+        $this->assertStringNotContainsString(self::TYPE_GUESSING_WARNING, $createOutput);
+        $this->assertStringContainsString(
+            '"'.self::TYPES_FROM_TOOL_IDENTIFIERS_KEY.'": "all"',
+            $this->getBaseLineFileContents(),
+        );
+
+        // The messages have been reworded (as happens between PHPStan releases) but the
+        // identifiers are unchanged, so only the genuinely new issue should be reported.
+        $removeOutput = $this->runRemoveBaseLineCommand(self::RESULTS_WITH_IDENTIFIERS_REWORDED_PLUS_NEW_ISSUE, 1);
+        $this->assertStringContainsString(self::NEW_ISSUE_IDENTIFIER, $removeOutput);
+        $this->assertStringContainsString('Issue count with baseline removed: 1', $removeOutput);
+        $this->assertStringNotContainsString('missingType.property', $removeOutput);
+        $this->assertStringNotContainsString(self::REGENERATE_RECOMMENDATION, $removeOutput);
+
+        // Only delete test directory if tests passed. Keep to investigate test failures
+        $this->removeTestDirectory();
+    }
+
+    public function testLegacyBaseLineWithIdentifierResults(): void
+    {
+        $this->setUpProjectWithCommit1();
+
+        $createOutput = $this->runCreateBaseLineCommand(self::RESULTS_WITHOUT_IDENTIFIERS);
+        $this->assertStringContainsString(self::TYPE_GUESSING_WARNING, $createOutput);
+        $this->assertStringNotContainsString(self::TYPES_FROM_TOOL_IDENTIFIERS_KEY, $this->getBaseLineFileContents());
+
+        // The baseline holds guessed types. The results now contain identifiers, so the baselined
+        // issues are matched via their legacy (guessed) types and the user is told to regenerate.
+        $removeOutput = $this->runRemoveBaseLineCommand(self::RESULTS_WITH_IDENTIFIERS_PLUS_NEW_ISSUE, 1);
+        $this->assertStringContainsString(self::REGENERATE_RECOMMENDATION, $removeOutput);
+        $this->assertStringContainsString(self::NEW_ISSUE_IDENTIFIER, $removeOutput);
+        $this->assertStringContainsString('Issue count with baseline removed: 1', $removeOutput);
+        $this->assertStringNotContainsString('missingType.property', $removeOutput);
+
+        // Only delete test directory if tests passed. Keep to investigate test failures
+        $this->removeTestDirectory();
+    }
+
+    public function testIdentifierBaseLineWithResultsMissingIdentifiers(): void
+    {
+        $this->setUpProjectWithCommit1();
+
+        $this->runCreateBaseLineCommand(self::RESULTS_WITH_IDENTIFIERS);
+
+        // Baseline was built from identifiers, results contain none (e.g. an older PHPStan).
+        // Nothing could be matched, so fail with a meaningful error.
+        $removeOutput = $this->runRemoveBaseLineCommand(self::RESULTS_WITHOUT_IDENTIFIERS, 17);
+        $this->assertStringContainsString(
+            'The baseline was created from results that contained type identifiers',
+            $removeOutput,
+        );
+
+        // Only delete test directory if tests passed. Keep to investigate test failures
+        $this->removeTestDirectory();
+    }
+
+    public function testLegacyBaseLineWithLegacyResults(): void
+    {
+        $this->setUpProjectWithCommit1();
+
+        $this->runCreateBaseLineCommand(self::RESULTS_WITHOUT_IDENTIFIERS);
+
+        // Neither baseline nor results contain identifiers: exactly the behaviour of previous
+        // SARB versions, with no new warnings.
+        $removeOutput = $this->runRemoveBaseLineCommand(self::RESULTS_WITHOUT_IDENTIFIERS, 0);
+        $this->assertStringContainsString('Issue count with baseline removed: 0', $removeOutput);
+        $this->assertStringNotContainsString(self::REGENERATE_RECOMMENDATION, $removeOutput);
+
+        // Only delete test directory if tests passed. Keep to investigate test failures
+        $this->removeTestDirectory();
+    }
+
+    private function setUpProjectWithCommit1(): void
+    {
+        $this->createTestDirectory();
+        $this->gitWrapper->init($this->projectRoot);
+
+        $source = $this->getPath(self::COMMIT_1_DIRECTORY);
+        $this->fileSystem->mirror($source, (string) $this->projectRoot, null, ['override' => true]);
+        $this->updatePathsInJsonFiles($this->projectRoot);
+        $this->gitWrapper->addAndCommit('Commit 1', $this->projectRoot);
+    }
+
+    private function runCreateBaseLineCommand(string $staticAnalysisOutputResource): string
+    {
+        $arguments = [
+            '--input-format' => 'phpstan-json',
+            '--project-root' => (string) $this->projectRoot,
+            'baseline-file' => $this->getBaselineFilePath(),
+        ];
+
+        return $this->runCommand(
+            CreateBaseLineCommand::COMMAND_NAME,
+            $arguments,
+            0,
+            $staticAnalysisOutputResource,
+        );
+    }
+
+    private function runRemoveBaseLineCommand(string $staticAnalysisOutputResource, int $expectedExitCode): string
+    {
+        $arguments = [
+            '--output-format' => 'json',
+            '--project-root' => (string) $this->projectRoot,
+            'baseline-file' => $this->getBaselineFilePath(),
+        ];
+
+        return $this->runCommand(
+            RemoveBaseLineFromResultsCommand::COMMAND_NAME,
+            $arguments,
+            $expectedExitCode,
+            $staticAnalysisOutputResource,
+        );
+    }
+
+    /**
+     * @param array<string, string|null> $arguments
+     */
+    private function runCommand(
+        string $commandName,
+        array $arguments,
+        int $expectedExitCode,
+        string $staticAnalysisOutputResource,
+    ): string {
+        $command = $this->application->find($commandName);
+        $commandTester = new CommandTester($command);
+        $arguments['command'] = $command->getName();
+
+        $commandTester->setInputs([$this->getStaticAnalysisResultsAsString($staticAnalysisOutputResource)]);
+
+        $actualExitCode = $commandTester->execute($arguments);
+        $output = $commandTester->getDisplay();
+        $this->assertSame($expectedExitCode, $actualExitCode, $output);
+
+        return $output;
+    }
+
+    private function getBaselineFilePath(): string
+    {
+        return "{$this->projectRoot}/baseline.json";
+    }
+
+    private function getBaseLineFileContents(): string
+    {
+        $contents = file_get_contents($this->getBaselineFilePath());
+        $this->assertNotFalse($contents);
+
+        return $contents;
+    }
+
+    private function getStaticAnalysisResultsAsString(string $resourceName): string
+    {
+        $fileName = __DIR__.'/../resources/integration/staticAnalysisOutput/'.$resourceName;
+        $rawResults = file_get_contents($fileName);
+        $this->assertNotFalse($rawResults);
+        $projectRootDirectory = (string) $this->projectRoot;
+
+        return str_replace('__SCRATCH_PAD_PATH__', $projectRootDirectory, $rawResults);
+    }
+
+    private function updatePathsInJsonFiles(ProjectRoot $projectRoot): void
+    {
+        $directory = $projectRoot->getProjectRootDirectory();
+
+        $files = scandir($directory);
+        $this->assertNotFalse($files);
+        foreach ($files as $file) {
+            if (StringUtils::endsWith('.json', $file)) {
+                $fullPath = Path::makeAbsolute($file, $directory);
+                $contents = file_get_contents($fullPath);
+                $this->assertNotFalse($contents);
+                $newContents = str_replace('__SCRATCH_PAD_PATH__', $directory, $contents);
+                file_put_contents($fullPath, $newContents);
+            }
+        }
+    }
+}

--- a/tests/Unit/Core/Analyser/BaseLineResultsRemoveTest.php
+++ b/tests/Unit/Core/Analyser/BaseLineResultsRemoveTest.php
@@ -125,4 +125,32 @@ final class BaseLineResultsRemoveTest extends TestCase
 
         $this->assertCount(0, $actualResults);
     }
+
+    public function testRemoveBaseLineResultsMatchedViaLegacyType(): void
+    {
+        $projectRoot = ProjectRoot::fromCurrentWorkingDirectory(self::PROJECT_ROOT_PATH);
+
+        // This issue is in the baseline as TYPE_1 (at line 10 at baseline time, now at line 11).
+        // The tool now provides a type identifier (so the type differs from the baseline entry),
+        // but the legacy type matches the baseline entry.
+        $latestAnalysisResultsBuilder = new AnalysisResultsBuilder();
+        $this->addAnalysisResult(
+            $latestAnalysisResultsBuilder,
+            $projectRoot,
+            self::FILE_1_FULL_PATH,
+            self::LINE_11,
+            'identifier.type',
+            Severity::error(),
+            self::TYPE_1,
+        );
+
+        $prunedAnalysisResults = $this->baseLineResultsRemover->pruneBaseLine(
+            $latestAnalysisResultsBuilder->build(),
+            $this->historyAnalyser,
+            $this->baselineAnalysisResults,
+            false,
+        );
+
+        $this->assertCount(0, $prunedAnalysisResults->getAnalysisResults());
+    }
 }

--- a/tests/Unit/Core/Analyser/internal/BaseLineResultsComparatorTest.php
+++ b/tests/Unit/Core/Analyser/internal/BaseLineResultsComparatorTest.php
@@ -134,4 +134,26 @@ final class BaseLineResultsComparatorTest extends TestCase
         $actual = $this->baseLineResultsComparator->isInBaseLine($location, new Type($type));
         $this->assertSame($expected, $actual);
     }
+
+    public function testInBaseLineViaLegacyType(): void
+    {
+        $location = PreviousLocation::fromFileNameAndLineNumber(
+            new RelativeFileName(self::FILE_1),
+            new LineNumber(self::LINE_1),
+        );
+
+        $actual = $this->baseLineResultsComparator->isInBaseLine($location, new Type('IDENTIFIER_TYPE'), new Type(self::TYPE_1));
+        $this->assertTrue($actual);
+    }
+
+    public function testNotInBaseLineWhenNeitherTypeNorLegacyTypeMatch(): void
+    {
+        $location = PreviousLocation::fromFileNameAndLineNumber(
+            new RelativeFileName(self::FILE_1),
+            new LineNumber(self::LINE_1),
+        );
+
+        $actual = $this->baseLineResultsComparator->isInBaseLine($location, new Type('IDENTIFIER_TYPE'), new Type(self::TYPE_2));
+        $this->assertFalse($actual);
+    }
 }

--- a/tests/Unit/Core/BaseLiner/BaseLineAnalysisResultTest.php
+++ b/tests/Unit/Core/BaseLiner/BaseLineAnalysisResultTest.php
@@ -113,6 +113,30 @@ final class BaseLineAnalysisResultTest extends TestCase
         $this->assertFalse($baseLineAnalysisResult->isMatch($previousLocation, new Type(self::TYPE_1)));
     }
 
+    public function testIsMatchViaLegacyType(): void
+    {
+        $baseLineAnalysisResult = $this->createBaseLineResult();
+        $location = PreviousLocation::fromFileNameAndLineNumber($this->relativeFileName, $this->lineNumber);
+        $this->assertTrue($baseLineAnalysisResult->isMatch($location, new Type(self::TYPE_2), new Type(self::TYPE_1)));
+    }
+
+    public function testIsMatchNeitherTypeNorLegacyTypeMatch(): void
+    {
+        $baseLineAnalysisResult = $this->createBaseLineResult();
+        $location = PreviousLocation::fromFileNameAndLineNumber($this->relativeFileName, $this->lineNumber);
+        $this->assertFalse($baseLineAnalysisResult->isMatch($location, new Type(self::TYPE_2), new Type(self::TYPE_2)));
+    }
+
+    public function testIsMatchLegacyTypeWithDifferentLineNumber(): void
+    {
+        $baseLineAnalysisResult = $this->createBaseLineResult();
+        $previousLocation = PreviousLocation::fromFileNameAndLineNumber(
+            $this->relativeFileName,
+            new LineNumber(self::LINE_NUMBER_2),
+        );
+        $this->assertFalse($baseLineAnalysisResult->isMatch($previousLocation, new Type(self::TYPE_2), new Type(self::TYPE_1)));
+    }
+
     /**
      * @return array<string,array{array<mixed>}>
      */

--- a/tests/Unit/Core/BaseLiner/BaseLineImporterTest.php
+++ b/tests/Unit/Core/BaseLiner/BaseLineImporterTest.php
@@ -67,6 +67,7 @@ final class BaseLineImporterTest extends TestCase
             ['baseline/invalid-results-parser.json'],
             ['baseline/invalid-history-analyser.json'],
             ['baseline/invalid-history-marker.json'],
+            ['baseline/invalid-types-from-identifiers.json'],
         ];
     }
 
@@ -94,6 +95,24 @@ final class BaseLineImporterTest extends TestCase
     {
         $baseLine = $this->getBaseLine('baseline/baseline.json');
         $this->assertCount(1, $baseLine->getAnalysisResults()->asArray());
+
+        // Baseline predates types from tool identifiers
+        $this->assertNull($baseLine->getTypeIdentifiersUsage()->asStringOrNull());
+    }
+
+    public function testBaseLineWithAllTypesFromToolIdentifiers(): void
+    {
+        $baseLine = $this->getBaseLine('baseline/baseline-types-from-identifiers-all.json');
+        $this->assertSame('all', $baseLine->getTypeIdentifiersUsage()->asStringOrNull());
+        $this->assertTrue($baseLine->getTypeIdentifiersUsage()->isAllFromToolIdentifiers());
+    }
+
+    public function testBaseLineWithSomeTypesFromToolIdentifiers(): void
+    {
+        $baseLine = $this->getBaseLine('baseline/baseline-types-from-identifiers-some.json');
+        $this->assertSame('some', $baseLine->getTypeIdentifiersUsage()->asStringOrNull());
+        $this->assertTrue($baseLine->getTypeIdentifiersUsage()->isFromToolIdentifiers());
+        $this->assertFalse($baseLine->getTypeIdentifiersUsage()->isAllFromToolIdentifiers());
     }
 
     private function getBaseLine(string $relativeFileName): BaseLine

--- a/tests/Unit/Core/Common/TypeIdentifiersUsageTest.php
+++ b/tests/Unit/Core/Common/TypeIdentifiersUsageTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Core\Common;
+
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\TypeIdentifiersUsage;
+use PHPUnit\Framework\TestCase;
+
+final class TypeIdentifiersUsageTest extends TestCase
+{
+    public function testNone(): void
+    {
+        $usage = TypeIdentifiersUsage::none();
+        $this->assertNull($usage->asStringOrNull());
+        $this->assertFalse($usage->isFromToolIdentifiers());
+        $this->assertFalse($usage->isAllFromToolIdentifiers());
+    }
+
+    public function testSome(): void
+    {
+        $usage = TypeIdentifiersUsage::some();
+        $this->assertSame('some', $usage->asStringOrNull());
+        $this->assertTrue($usage->isFromToolIdentifiers());
+        $this->assertFalse($usage->isAllFromToolIdentifiers());
+    }
+
+    public function testAll(): void
+    {
+        $usage = TypeIdentifiersUsage::all();
+        $this->assertSame('all', $usage->asStringOrNull());
+        $this->assertTrue($usage->isFromToolIdentifiers());
+        $this->assertTrue($usage->isAllFromToolIdentifiers());
+    }
+
+    public function testFromNull(): void
+    {
+        $usage = TypeIdentifiersUsage::fromStringOrNull(null);
+        $this->assertNull($usage->asStringOrNull());
+        $this->assertFalse($usage->isFromToolIdentifiers());
+    }
+
+    public function testFromAll(): void
+    {
+        $usage = TypeIdentifiersUsage::fromStringOrNull('all');
+        $this->assertSame('all', $usage->asStringOrNull());
+        $this->assertTrue($usage->isAllFromToolIdentifiers());
+    }
+
+    public function testFromSome(): void
+    {
+        $usage = TypeIdentifiersUsage::fromStringOrNull('some');
+        $this->assertSame('some', $usage->asStringOrNull());
+        $this->assertTrue($usage->isFromToolIdentifiers());
+        $this->assertFalse($usage->isAllFromToolIdentifiers());
+    }
+
+    public function testUnrecognisedStringTreatedAsSome(): void
+    {
+        $usage = TypeIdentifiersUsage::fromStringOrNull('rubbish');
+        $this->assertSame('some', $usage->asStringOrNull());
+        $this->assertTrue($usage->isFromToolIdentifiers());
+        $this->assertFalse($usage->isAllFromToolIdentifiers());
+    }
+}

--- a/tests/Unit/Core/Pruner/PrunedResultsTest.php
+++ b/tests/Unit/Core/Pruner/PrunedResultsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Core\Pruner;
+
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\BaseLine;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\TypeIdentifiersUsage;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Pruner\PrunedResults;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResults;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResultsBuilder;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\GitDiffHistoryAnalyser\GitCommit;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\ResultsParsers\SarbJsonResultsParser\SarbJsonResultsParser;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Helpers\AnalysisResultsAdderTrait;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Helpers\BaseLineResultsBuilder;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Tests\TestDoubles\HistoryFactoryStub;
+use PHPUnit\Framework\TestCase;
+
+final class PrunedResultsTest extends TestCase
+{
+    use AnalysisResultsAdderTrait;
+
+    public function testGetters(): void
+    {
+        $baseLine = $this->createBaseLine(null, 1);
+        $prunedAnalysisResults = new AnalysisResults([]);
+        $inputAnalysisResults = $this->createInputResults(false);
+
+        $prunedResults = new PrunedResults($baseLine, $prunedAnalysisResults, $inputAnalysisResults);
+
+        $this->assertSame($baseLine, $prunedResults->getBaseLine());
+        $this->assertSame($prunedAnalysisResults, $prunedResults->getPrunedResults());
+        $this->assertSame($inputAnalysisResults, $prunedResults->getInputAnalysisResults());
+    }
+
+    public function testRecommendRegeneratingWhenLegacyBaseLineAndInputHasTypeIdentifiers(): void
+    {
+        $prunedResults = new PrunedResults(
+            $this->createBaseLine(null, 1),
+            new AnalysisResults([]),
+            $this->createInputResults(true),
+        );
+
+        $this->assertTrue($prunedResults->shouldRecommendRegeneratingBaseLine());
+    }
+
+    public function testNoRecommendationWhenInputHasNoTypeIdentifiers(): void
+    {
+        $prunedResults = new PrunedResults(
+            $this->createBaseLine(null, 1),
+            new AnalysisResults([]),
+            $this->createInputResults(false),
+        );
+
+        $this->assertFalse($prunedResults->shouldRecommendRegeneratingBaseLine());
+    }
+
+    public function testNoRecommendationWhenBaseLineIsEmpty(): void
+    {
+        $prunedResults = new PrunedResults(
+            $this->createBaseLine(null, 0),
+            new AnalysisResults([]),
+            $this->createInputResults(true),
+        );
+
+        $this->assertFalse($prunedResults->shouldRecommendRegeneratingBaseLine());
+    }
+
+    public function testNoRecommendationWhenBaseLineUsesTypeIdentifiers(): void
+    {
+        $prunedResults = new PrunedResults(
+            $this->createBaseLine(TypeIdentifiersUsage::all(), 1),
+            new AnalysisResults([]),
+            $this->createInputResults(true),
+        );
+
+        $this->assertFalse($prunedResults->shouldRecommendRegeneratingBaseLine());
+    }
+
+    private function createBaseLine(?TypeIdentifiersUsage $typeIdentifiersUsage, int $resultCount): BaseLine
+    {
+        $baseLineResultsBuilder = new BaseLineResultsBuilder();
+        for ($i = 0; $i < $resultCount; ++$i) {
+            $baseLineResultsBuilder->add('file1', $i + 1, "type$i", Severity::error());
+        }
+
+        return new BaseLine(
+            new HistoryFactoryStub(),
+            $baseLineResultsBuilder->build(),
+            new SarbJsonResultsParser(),
+            new GitCommit('fae40b3d596780ffd746dbd2300d05dcfbd09033'),
+            $typeIdentifiersUsage,
+        );
+    }
+
+    private function createInputResults(bool $withLegacyType): AnalysisResults
+    {
+        $projectRoot = ProjectRoot::fromCurrentWorkingDirectory('/');
+        $analysisResultsBuilder = new AnalysisResultsBuilder();
+        $this->addAnalysisResult(
+            $analysisResultsBuilder,
+            $projectRoot,
+            '/FILE_1',
+            1,
+            'TYPE_1',
+            Severity::error(),
+            $withLegacyType ? 'LEGACY_TYPE_1' : null,
+        );
+
+        return $analysisResultsBuilder->build();
+    }
+}

--- a/tests/Unit/Core/ResultsParser/AnalysisResultTest.php
+++ b/tests/Unit/Core/ResultsParser/AnalysisResultTest.php
@@ -16,6 +16,7 @@ final class AnalysisResultTest extends TestCase
     private const FILE_NAME = '/tmp/foo.php';
     private const LINE_NUMBER = 10;
     private const TYPE = 'TYPE';
+    private const LEGACY_TYPE = 'LEGACY_TYPE';
     private const MESSAGE = 'message';
     private const FULL_DETAILS = [
         'snippet' => 'class Foo',
@@ -44,5 +45,35 @@ final class AnalysisResultTest extends TestCase
         $this->assertSame(self::TYPE, $analysisResult->getType()->getType());
         $this->assertSame(self::MESSAGE, $analysisResult->getMessage());
         $this->assertSame(self::FULL_DETAILS, $analysisResult->getFullDetails());
+        $this->assertNull($analysisResult->getLegacyType());
+    }
+
+    public function testWithLegacyType(): void
+    {
+        $projectRoot = ProjectRoot::fromCurrentWorkingDirectory('/');
+
+        $location = Location::fromAbsoluteFileName(
+            new AbsoluteFileName(self::FILE_NAME),
+            $projectRoot,
+            new LineNumber(self::LINE_NUMBER),
+        );
+
+        $analysisResult = new AnalysisResult(
+            $location,
+            new Type(self::TYPE),
+            self::MESSAGE,
+            self::FULL_DETAILS,
+            Severity::error(),
+            new Type(self::LEGACY_TYPE),
+        );
+
+        $this->assertSame(self::TYPE, $analysisResult->getType()->getType());
+        $legacyType = $analysisResult->getLegacyType();
+        $this->assertNotNull($legacyType);
+        $this->assertSame(self::LEGACY_TYPE, $legacyType->getType());
+
+        // The baseline entry should hold the (primary) type, not the legacy type
+        $baseLineAnalysisResult = $analysisResult->asBaseLineAnalysisResult();
+        $this->assertSame(self::TYPE, $baseLineAnalysisResult->getType()->getType());
     }
 }

--- a/tests/Unit/Core/ResultsParser/AnalysisResultsTest.php
+++ b/tests/Unit/Core/ResultsParser/AnalysisResultsTest.php
@@ -57,6 +57,36 @@ final class AnalysisResultsTest extends TestCase
         $this->assertSame([$analysisResult], $analysisResults->getAnalysisResults());
     }
 
+    public function testTypeIdentifiersUsageWithNoResults(): void
+    {
+        $analysisResults = $this->analysisResultsBuilder->build();
+        $this->assertNull($analysisResults->getTypeIdentifiersUsage()->asStringOrNull());
+    }
+
+    public function testTypeIdentifiersUsageWithNoLegacyTypes(): void
+    {
+        $this->addAnalysisResult($this->analysisResultsBuilder, $this->projectRoot, self::FILE_A, self::LINE_1, self::TYPE, Severity::error());
+        $this->addAnalysisResult($this->analysisResultsBuilder, $this->projectRoot, self::FILE_A, self::LINE_2, self::TYPE, Severity::error());
+        $analysisResults = $this->analysisResultsBuilder->build();
+        $this->assertNull($analysisResults->getTypeIdentifiersUsage()->asStringOrNull());
+    }
+
+    public function testTypeIdentifiersUsageWithSomeLegacyTypes(): void
+    {
+        $this->addAnalysisResult($this->analysisResultsBuilder, $this->projectRoot, self::FILE_A, self::LINE_1, self::TYPE, Severity::error(), 'LEGACY_TYPE');
+        $this->addAnalysisResult($this->analysisResultsBuilder, $this->projectRoot, self::FILE_A, self::LINE_2, self::TYPE, Severity::error());
+        $analysisResults = $this->analysisResultsBuilder->build();
+        $this->assertSame('some', $analysisResults->getTypeIdentifiersUsage()->asStringOrNull());
+    }
+
+    public function testTypeIdentifiersUsageWithAllLegacyTypes(): void
+    {
+        $this->addAnalysisResult($this->analysisResultsBuilder, $this->projectRoot, self::FILE_A, self::LINE_1, self::TYPE, Severity::error(), 'LEGACY_TYPE');
+        $this->addAnalysisResult($this->analysisResultsBuilder, $this->projectRoot, self::FILE_A, self::LINE_2, self::TYPE, Severity::error(), 'LEGACY_TYPE');
+        $analysisResults = $this->analysisResultsBuilder->build();
+        $this->assertSame('all', $analysisResults->getTypeIdentifiersUsage()->asStringOrNull());
+    }
+
     public function test3AnalysisResultsAreOrderedCorrectly(): void
     {
         $analysisResult1 = $this->buildAnalysisResult($this->projectRoot, self::FILE_A, self::LINE_1, self::TYPE, Severity::error());

--- a/tests/Unit/Framework/Command/CreateBaseLineCommandTest.php
+++ b/tests/Unit/Framework/Command/CreateBaseLineCommandTest.php
@@ -4,6 +4,7 @@ namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Framework\Comm
 
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\BaseLineFileName;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\TypeIdentifiersUsage;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\HistoryAnalyser\HistoryFactory;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\HistoryAnalyser\UnifiedDiffParser\Parser;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\ErrorReportedByStaticAnalysisTool;
@@ -121,6 +122,46 @@ EOF;
             '[results-parser-stub] guesses the classification of violations. This means results might not be 100% accurate.',
             $commandTester,
         );
+    }
+
+    public function testNoTypeGuessingWarningWhenAllTypesFromToolIdentifiers(): void
+    {
+        $commandTester = $this->createCommandTester(
+            $this->defaultHistoryFactory,
+            $this->resultsParser2,
+            self::BASELINE_FILENAME,
+            null,
+            null,
+            TypeIdentifiersUsage::all(),
+        );
+
+        $commandTester->execute([
+            self::INPUT_FORMAT_OPTION => ResultsParserStubIdentifier::CODE,
+            self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
+        ]);
+
+        $this->assertReturnCode(0, $commandTester);
+        $this->assertResponseDoesNotContain('guesses the classification of violations', $commandTester);
+    }
+
+    public function testTypeGuessingWarningShownWhenOnlySomeTypesFromToolIdentifiers(): void
+    {
+        $commandTester = $this->createCommandTester(
+            $this->defaultHistoryFactory,
+            $this->resultsParser2,
+            self::BASELINE_FILENAME,
+            null,
+            null,
+            TypeIdentifiersUsage::some(),
+        );
+
+        $commandTester->execute([
+            self::INPUT_FORMAT_OPTION => ResultsParserStubIdentifier::CODE,
+            self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
+        ]);
+
+        $this->assertReturnCode(0, $commandTester);
+        $this->assertResponseContains('guesses the classification of violations', $commandTester);
     }
 
     public function testPickNonDefaultHistoryAnalyser(): void
@@ -249,6 +290,7 @@ EOF;
         string $baselineFileName,
         ?ProjectRoot $projectRoot,
         ?\Throwable $exception,
+        ?TypeIdentifiersUsage $typeIdentifiersUsage = null,
     ): CommandTester {
         $mockBaseLineCreator = new MockBaseLineCreator(
             $expectedHistoryFactory,
@@ -257,6 +299,7 @@ EOF;
             $projectRoot,
             self::INPUT_STRING_1, // CommandTest adds line end
             $exception,
+            $typeIdentifiersUsage,
         );
 
         $command = new CreateBaseLineCommand(
@@ -281,5 +324,11 @@ EOF;
         $output = $commandTester->getDisplay();
         $position = strpos($output, $expectedMessage);
         $this->assertNotFalse($position, "Can't find message [$expectedMessage] in [$output]");
+    }
+
+    private function assertResponseDoesNotContain(string $unexpectedMessage, CommandTester $commandTester): void
+    {
+        $output = $commandTester->getDisplay();
+        $this->assertStringNotContainsString($unexpectedMessage, $output);
     }
 }

--- a/tests/Unit/Framework/Command/MockBaseLineCreator.php
+++ b/tests/Unit/Framework/Command/MockBaseLineCreator.php
@@ -6,6 +6,7 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\BaseLiner\BaseLineAnalys
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\BaseLine;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\BaseLineFileName;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\TypeIdentifiersUsage;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Creator\BaseLineCreatorInterface;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\HistoryAnalyser\HistoryFactory;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\ResultsParser;
@@ -24,6 +25,7 @@ final class MockBaseLineCreator implements BaseLineCreatorInterface
         private ?ProjectRoot $expectedProjectRoot,
         private string $expectedAnalysisResultsAsString,
         private ?\Throwable $throwable,
+        private ?TypeIdentifiersUsage $typeIdentifiersUsage = null,
     ) {
     }
 
@@ -54,6 +56,6 @@ final class MockBaseLineCreator implements BaseLineCreatorInterface
         $analysisResults = BaseLineAnalysisResults::fromArray([]);
         $historyMarker = new GitCommit('9cf13d75cdf3addb82f507b68f4990725748d7af');
 
-        return new BaseLine($historyFactory, $analysisResults, $resultsParser, $historyMarker);
+        return new BaseLine($historyFactory, $analysisResults, $resultsParser, $historyMarker, $this->typeIdentifiersUsage);
     }
 }

--- a/tests/Unit/Framework/Command/RemoveBaseLineCommandTest.php
+++ b/tests/Unit/Framework/Command/RemoveBaseLineCommandTest.php
@@ -10,6 +10,7 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Type;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\OutputFormatter\OutputFormatter;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Pruner\InputMissingTypeIdentifiersException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Pruner\PrunedResults;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\RandomResultsPicker\RandomResultsPicker;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResult;
@@ -88,6 +89,40 @@ EOF;
         $this->assertResponseContains('Latest analysis issue count: 2', $commandTester);
         $this->assertResponseContains('Baseline issue count: 4', $commandTester);
         $this->assertResponseContains('Issue count with baseline removed: 0', $commandTester);
+        $this->assertResponseDoesNotContain('Regenerate the baseline', $commandTester);
+    }
+
+    public function testRecommendRegeneratingBaseLineWhenInputContainsTypeIdentifiers(): void
+    {
+        $commandTester = $this->createCommandTester(
+            $this->getAnalysisResultsWithXResults(0),
+            null,
+            null,
+            $this->getAnalysisResultsWithXResults(2, true),
+        );
+
+        $commandTester->execute([
+            self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
+        ]);
+
+        $this->assertReturnCode(0, $commandTester);
+        $this->assertResponseContains('Regenerate the baseline', $commandTester);
+    }
+
+    public function testInputMissingTypeIdentifiers(): void
+    {
+        $commandTester = $this->createCommandTester(
+            $this->getAnalysisResultsWithXResults(1),
+            null,
+            InputMissingTypeIdentifiersException::baseLineBuiltFromTypeIdentifiers(),
+        );
+
+        $commandTester->execute([
+            self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
+        ]);
+
+        $this->assertReturnCode(17, $commandTester);
+        $this->assertResponseContains('The baseline was created from results that contained type identifiers', $commandTester);
     }
 
     public function test1NewIssues(): void
@@ -214,14 +249,15 @@ EOF;
 
         $this->assertResponseContains('Random 2 issues in the baseline to fix...', $commandTester);
         $this->assertResponseContains('FILE: /FILE_2', $commandTester);
-        $this->assertResponseContains('| 2    | MESSAGE_1   |', $commandTester);
-        $this->assertResponseContains('| 2    | MESSAGE_0   |', $commandTester);
+        $this->assertResponseContains('| 2    | TYPE_1 | MESSAGE_1   |', $commandTester);
+        $this->assertResponseContains('| 2    | TYPE_0 | MESSAGE_0   |', $commandTester);
     }
 
     private function createCommandTester(
         AnalysisResults $expectedAnalysisResults,
         ?ProjectRoot $projectRoot,
         ?\Throwable $exception,
+        ?AnalysisResults $inputAnalysisResults = null,
     ): CommandTester {
         $baseLineResultsBuilder = new BaseLineResultsBuilder();
         $baseLineResultsBuilder->add('file1', 1, 'type1', Severity::error());
@@ -239,7 +275,7 @@ EOF;
         $prunedResults = new PrunedResults(
             $baseLine,
             $expectedAnalysisResults,
-            $this->getAnalysisResultsWithXResults(2),
+            $inputAnalysisResults ?? $this->getAnalysisResultsWithXResults(2),
         );
 
         $mockResultsPruner = new MockResultsPruner(
@@ -274,7 +310,13 @@ EOF;
         $this->assertNotFalse($position, "Can't find message [$expectedMessage] in [$output]");
     }
 
-    private function getAnalysisResultsWithXResults(int $count): AnalysisResults
+    private function assertResponseDoesNotContain(string $unexpectedMessage, CommandTester $commandTester): void
+    {
+        $output = $commandTester->getDisplay();
+        $this->assertStringNotContainsString($unexpectedMessage, $output);
+    }
+
+    private function getAnalysisResultsWithXResults(int $count, bool $withLegacyTypes = false): AnalysisResults
     {
         $projectRoot = ProjectRoot::fromCurrentWorkingDirectory('/');
 
@@ -290,6 +332,7 @@ EOF;
                 "MESSAGE_$i",
                 [],
                 Severity::error(),
+                $withLegacyTypes ? new Type("LEGACY_TYPE_$i") : null,
             );
             $analysisResultsBuilder->addAnalysisResult($analysisResult);
         }

--- a/tests/Unit/Plugins/OutputFormatters/GithubActionsOutputFormatterTest.php
+++ b/tests/Unit/Plugins/OutputFormatters/GithubActionsOutputFormatterTest.php
@@ -2,7 +2,15 @@
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\OutputFormatters;
 
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\AbsoluteFileName;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\LineNumber;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Location;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Type;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\OutputFormatter\OutputFormatter;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResult;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResultsBuilder;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\OutputFormatters\GithubActionsOutputFormatter;
 
 final class GithubActionsOutputFormatterTest extends AbstractOutputFormatterTestCase
@@ -20,12 +28,35 @@ final class GithubActionsOutputFormatterTest extends AbstractOutputFormatterTest
     public function testWithIssues(): void
     {
         $expectedOutput = <<<EOF
-::error file=FILE_1,line=10::MESSAGE_1
-::error file=FILE_1,line=12::MESSAGE_2
-::warning file=FILE_2,line=0::MESSAGE_3
+::error file=FILE_1,line=10,title=TYPE_1::MESSAGE_1
+::error file=FILE_1,line=12,title=TYPE_2::MESSAGE_2
+::warning file=FILE_2,line=0,title=TYPE_1::MESSAGE_3
 EOF;
 
         $this->assertIssuesOutput($expectedOutput);
+    }
+
+    public function testTypeIsEscapedAsWorkflowCommandProperty(): void
+    {
+        $projectRoot = ProjectRoot::fromCurrentWorkingDirectory('/');
+        $location = Location::fromAbsoluteFileName(
+            new AbsoluteFileName('/FILE_1'),
+            $projectRoot,
+            new LineNumber(10),
+        );
+        $analysisResult = new AnalysisResult(
+            $location,
+            new Type("Method foo, bar: 100% \r\n broken"),
+            'MESSAGE_1',
+            [],
+            Severity::error(),
+        );
+        $analysisResultsBuilder = new AnalysisResultsBuilder();
+        $analysisResultsBuilder->addAnalysisResult($analysisResult);
+
+        $expectedOutput = '::error file=FILE_1,line=10,title=Method foo%2C bar%3A 100%25 %0D%0A broken::MESSAGE_1';
+
+        $this->assertSame($expectedOutput, $this->getOutputFormatter()->outputResults($analysisResultsBuilder->build()));
     }
 
     protected function getOutputFormatter(): OutputFormatter

--- a/tests/Unit/Plugins/OutputFormatters/TableOutputFormatterTest.php
+++ b/tests/Unit/Plugins/OutputFormatters/TableOutputFormatterTest.php
@@ -26,19 +26,19 @@ EOF;
         $expectedOutput = <<<EOF
 
 FILE: /FILE_1
-+------+-------------+
-| Line | Description |
-+------+-------------+
-| 10   | MESSAGE_1   |
-| 12   | MESSAGE_2   |
-+------+-------------+
++------+--------+-------------+
+| Line | Type   | Description |
++------+--------+-------------+
+| 10   | TYPE_1 | MESSAGE_1   |
+| 12   | TYPE_2 | MESSAGE_2   |
++------+--------+-------------+
 
 FILE: /FILE_2
-+------+--------------------+
-| Line | Description        |
-+------+--------------------+
-| 0    | WARNING: MESSAGE_3 |
-+------+--------------------+
++------+--------+--------------------+
+| Line | Type   | Description        |
++------+--------+--------------------+
+| 0    | TYPE_1 | WARNING: MESSAGE_3 |
++------+--------+--------------------+
 
 These results include warnings. To exclude warnings from output use the --ignore-warnings flag.
 
@@ -52,12 +52,12 @@ EOF;
         $expectedOutput = <<<EOF
 
 FILE: /FILE_1
-+------+-------------+
-| Line | Description |
-+------+-------------+
-| 10   | MESSAGE_1   |
-| 12   | MESSAGE_2   |
-+------+-------------+
++------+--------+-------------+
+| Line | Type   | Description |
++------+--------+-------------+
+| 10   | TYPE_1 | MESSAGE_1   |
+| 12   | TYPE_2 | MESSAGE_2   |
++------+--------+-------------+
 
 EOF;
 

--- a/tests/Unit/Plugins/ResultsParsers/PhpstanJsonResultsParser/PhpstanJsonResultsParserTest.php
+++ b/tests/Unit/Plugins/ResultsParsers/PhpstanJsonResultsParser/PhpstanJsonResultsParserTest.php
@@ -77,6 +77,93 @@ final class PhpstanJsonResultsParserTest extends TestCase
             'PHPDoc tag @param for parameter $array with type array is incompatible with native type int',
             Severity::error(),
         );
+
+        // No identifiers in the results, so no legacy types
+        $this->assertNull($result1->getLegacyType());
+        $this->assertNull($result2->getLegacyType());
+        $this->assertNull($result3->getLegacyType());
+    }
+
+    public function testConversionFromStringWithIdentifiers(): void
+    {
+        $fileContents = $this->getResource('phpstan/phpstan-with-identifiers.json');
+        $analysisResults = $this->phpstanJsonResultsParser->convertFromString($fileContents, $this->projectRoot);
+
+        $this->assertCount(3, $analysisResults->getAnalysisResults());
+
+        $result1 = $analysisResults->getAnalysisResults()[0];
+        $result2 = $analysisResults->getAnalysisResults()[1];
+        $result3 = $analysisResults->getAnalysisResults()[2];
+
+        // Type comes from the identifier supplied by PHPStan
+        $this->assertMatch($result1,
+            'src/Domain/BaseLiner/BaseLineImporter.php',
+            89,
+            'argument.type',
+            Severity::error(),
+        );
+
+        // The message is still the full message
+        $this->assertSame(
+            'Parameter #1 $array of static method DaveLiddament\\StaticAnalysisResultsBaseliner\\Domain\\ResultsParser\\AnalysisResults::fromArray() expects int, array given.',
+            $result1->getMessage(),
+        );
+
+        // The legacy type is the type as guessed from the message (used to match old baselines)
+        $legacyType1 = $result1->getLegacyType();
+        $this->assertNotNull($legacyType1);
+        $this->assertSame(
+            'Parameter #1 $array of static method expects int, array given.',
+            $legacyType1->getType(),
+        );
+
+        $this->assertMatch($result2,
+            'src/Domain/ResultsParser/AnalysisResults.php',
+            0,
+            'foreach.nonIterable',
+            Severity::error(),
+        );
+
+        $this->assertMatch($result3,
+            'src/Domain/ResultsParser/AnalysisResults.php',
+            73,
+            'parameter.phpDocType',
+            Severity::error(),
+        );
+
+        $this->assertSame('all', $analysisResults->getTypeIdentifiersUsage()->asStringOrNull());
+    }
+
+    public function testConversionFromStringWithMixedIdentifiers(): void
+    {
+        $fileContents = $this->getResource('phpstan/phpstan-mixed-identifiers.json');
+        $analysisResults = $this->phpstanJsonResultsParser->convertFromString($fileContents, $this->projectRoot);
+
+        $this->assertCount(3, $analysisResults->getAnalysisResults());
+
+        $result1 = $analysisResults->getAnalysisResults()[0];
+        $result2 = $analysisResults->getAnalysisResults()[1];
+        $result3 = $analysisResults->getAnalysisResults()[2];
+
+        // Identifier supplied
+        $this->assertSame('argument.type', $result1->getType()->getType());
+        $this->assertNotNull($result1->getLegacyType());
+
+        // Empty identifier: treated as if no identifier supplied
+        $this->assertSame(
+            'Argument of an invalid type int supplied for foreach, only iterables are supported.',
+            $result2->getType()->getType(),
+        );
+        $this->assertNull($result2->getLegacyType());
+
+        // No identifier: type guessed from the message
+        $this->assertSame(
+            'PHPDoc tag @param for parameter $array with type array is incompatible with native type int',
+            $result3->getType()->getType(),
+        );
+        $this->assertNull($result3->getLegacyType());
+
+        $this->assertSame('some', $analysisResults->getTypeIdentifiersUsage()->asStringOrNull());
     }
 
     public function testTypeGuesser(): void
@@ -103,6 +190,7 @@ final class PhpstanJsonResultsParserTest extends TestCase
             ['phpstan/phpstan-invalid-missing-line.json'],
             ['phpstan/phpstan-invalid-missing-errors.json'],
             ['phpstan/phpstan-invalid-errors-not-strings.json'],
+            ['phpstan/phpstan-invalid-identifier.json'],
         ];
     }
 

--- a/tests/resources/baseline/baseline-types-from-identifiers-all.json
+++ b/tests/resources/baseline/baseline-types-from-identifiers-all.json
@@ -1,0 +1,15 @@
+{
+  "historyMarker": "9be6101dc6848d67b5958a5762494060062e42ec",
+  "historyAnalyser": "git",
+  "resultsParser": "sarb-json",
+  "typesFromToolIdentifiers": "all",
+  "analysisResults": [
+    {
+      "lineNumber": 10,
+      "fileName": "FILE_1",
+      "type": "identifier.type",
+      "message": "MESSAGE_1",
+      "severity": "error"
+    }
+  ]
+}

--- a/tests/resources/baseline/baseline-types-from-identifiers-some.json
+++ b/tests/resources/baseline/baseline-types-from-identifiers-some.json
@@ -1,0 +1,22 @@
+{
+  "historyMarker": "9be6101dc6848d67b5958a5762494060062e42ec",
+  "historyAnalyser": "git",
+  "resultsParser": "sarb-json",
+  "typesFromToolIdentifiers": "some",
+  "analysisResults": [
+    {
+      "lineNumber": 10,
+      "fileName": "FILE_1",
+      "type": "identifier.type",
+      "message": "MESSAGE_1",
+      "severity": "error"
+    },
+    {
+      "lineNumber": 12,
+      "fileName": "FILE_1",
+      "type": "TYPE_2",
+      "message": "MESSAGE_2",
+      "severity": "error"
+    }
+  ]
+}

--- a/tests/resources/baseline/invalid-types-from-identifiers.json
+++ b/tests/resources/baseline/invalid-types-from-identifiers.json
@@ -1,0 +1,7 @@
+{
+  "historyMarker": "9be6101dc6848d67b5958a5762494060062e42ec",
+  "historyAnalyser": "git",
+  "resultsParser": "sarb-json",
+  "typesFromToolIdentifiers": 123,
+  "analysisResults": []
+}

--- a/tests/resources/integration/staticAnalysisOutput/phpstan-identifiers-plus-new.json
+++ b/tests/resources/integration/staticAnalysisOutput/phpstan-identifiers-plus-new.json
@@ -1,0 +1,37 @@
+{
+  "totals": {
+    "errors": 0,
+    "file_errors": 3
+  },
+  "files": {
+    "__SCRATCH_PAD_PATH__/src/Person.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Property DaveLiddament\\DummyProject\\Person::$name has no type specified.",
+          "line": 15,
+          "ignorable": true,
+          "identifier": "missingType.property"
+        }
+      ]
+    },
+    "__SCRATCH_PAD_PATH__/src/PersonFinder.php": {
+      "errors": 2,
+      "messages": [
+        {
+          "message": "Method DaveLiddament\\DummyProject\\PersonFinder::find() has parameter $name with no type specified.",
+          "line": 15,
+          "ignorable": true,
+          "identifier": "missingType.parameter"
+        },
+        {
+          "message": "Call to an undefined method DaveLiddament\\DummyProject\\Person::getFullName().",
+          "line": 17,
+          "ignorable": true,
+          "identifier": "method.notFound"
+        }
+      ]
+    }
+  },
+  "errors": []
+}

--- a/tests/resources/integration/staticAnalysisOutput/phpstan-identifiers-reworded-plus-new.json
+++ b/tests/resources/integration/staticAnalysisOutput/phpstan-identifiers-reworded-plus-new.json
@@ -1,0 +1,37 @@
+{
+  "totals": {
+    "errors": 0,
+    "file_errors": 3
+  },
+  "files": {
+    "__SCRATCH_PAD_PATH__/src/Person.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Property DaveLiddament\\DummyProject\\Person::$name does not have a type specified.",
+          "line": 15,
+          "ignorable": true,
+          "identifier": "missingType.property"
+        }
+      ]
+    },
+    "__SCRATCH_PAD_PATH__/src/PersonFinder.php": {
+      "errors": 2,
+      "messages": [
+        {
+          "message": "Method DaveLiddament\\DummyProject\\PersonFinder::find() has parameter $name without any type specified.",
+          "line": 15,
+          "ignorable": true,
+          "identifier": "missingType.parameter"
+        },
+        {
+          "message": "Call to an undefined method DaveLiddament\\DummyProject\\Person::getFullName().",
+          "line": 17,
+          "ignorable": true,
+          "identifier": "method.notFound"
+        }
+      ]
+    }
+  },
+  "errors": []
+}

--- a/tests/resources/integration/staticAnalysisOutput/phpstan-identifiers.json
+++ b/tests/resources/integration/staticAnalysisOutput/phpstan-identifiers.json
@@ -1,0 +1,31 @@
+{
+  "totals": {
+    "errors": 0,
+    "file_errors": 2
+  },
+  "files": {
+    "__SCRATCH_PAD_PATH__/src/Person.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Property DaveLiddament\\DummyProject\\Person::$name has no type specified.",
+          "line": 15,
+          "ignorable": true,
+          "identifier": "missingType.property"
+        }
+      ]
+    },
+    "__SCRATCH_PAD_PATH__/src/PersonFinder.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Method DaveLiddament\\DummyProject\\PersonFinder::find() has parameter $name with no type specified.",
+          "line": 15,
+          "ignorable": true,
+          "identifier": "missingType.parameter"
+        }
+      ]
+    }
+  },
+  "errors": []
+}

--- a/tests/resources/integration/staticAnalysisOutput/phpstan-no-identifiers.json
+++ b/tests/resources/integration/staticAnalysisOutput/phpstan-no-identifiers.json
@@ -1,0 +1,29 @@
+{
+  "totals": {
+    "errors": 0,
+    "file_errors": 2
+  },
+  "files": {
+    "__SCRATCH_PAD_PATH__/src/Person.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Property DaveLiddament\\DummyProject\\Person::$name has no type specified.",
+          "line": 15,
+          "ignorable": true
+        }
+      ]
+    },
+    "__SCRATCH_PAD_PATH__/src/PersonFinder.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Method DaveLiddament\\DummyProject\\PersonFinder::find() has parameter $name with no type specified.",
+          "line": 15,
+          "ignorable": true
+        }
+      ]
+    }
+  },
+  "errors": []
+}

--- a/tests/resources/phpstan/phpstan-invalid-identifier.json
+++ b/tests/resources/phpstan/phpstan-invalid-identifier.json
@@ -1,0 +1,21 @@
+{
+  "totals": {
+    "errors": 0,
+    "file_errors": 1
+  },
+  "files": {
+    "/vagrant/static-analysis-baseliner/src/Domain/BaseLiner/BaseLineImporter.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Parameter #1 $array of static method DaveLiddament\\StaticAnalysisResultsBaseliner\\Domain\\ResultsParser\\AnalysisResults::fromArray() expects int, array given.",
+          "line": 89,
+          "ignorable": true,
+          "identifier": 123,
+          "relativePath": "Domain/BaseLiner/BaseLineImporter.php"
+        }
+      ]
+    }
+  },
+  "errors": []
+}

--- a/tests/resources/phpstan/phpstan-mixed-identifiers.json
+++ b/tests/resources/phpstan/phpstan-mixed-identifiers.json
@@ -1,0 +1,39 @@
+{
+  "totals": {
+    "errors": 0,
+    "file_errors": 3
+  },
+  "files": {
+    "/vagrant/static-analysis-baseliner/src/Domain/BaseLiner/BaseLineImporter.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Parameter #1 $array of static method DaveLiddament\\StaticAnalysisResultsBaseliner\\Domain\\ResultsParser\\AnalysisResults::fromArray() expects int, array given.",
+          "line": 89,
+          "ignorable": true,
+          "identifier": "argument.type",
+          "relativePath": "Domain/BaseLiner/BaseLineImporter.php"
+        }
+      ]
+    },
+    "/vagrant/static-analysis-baseliner/src/Domain/ResultsParser/AnalysisResults.php": {
+      "errors": 2,
+      "messages": [
+        {
+          "message": "PHPDoc tag @param for parameter $array with type array is incompatible with native type int",
+          "line": 73,
+          "ignorable": true,
+          "relativePath": "Domain/ResultsParser/AnalysisResults.php"
+        },
+        {
+          "message": "Argument of an invalid type int supplied for foreach, only iterables are supported.",
+          "line": null,
+          "ignorable": true,
+          "identifier": "",
+          "relativePath": "Domain/ResultsParser/AnalysisResults.php"
+        }
+      ]
+    }
+  },
+  "errors": []
+}

--- a/tests/resources/phpstan/phpstan-with-identifiers.json
+++ b/tests/resources/phpstan/phpstan-with-identifiers.json
@@ -1,0 +1,40 @@
+{
+  "totals": {
+    "errors": 0,
+    "file_errors": 3
+  },
+  "files": {
+    "/vagrant/static-analysis-baseliner/src/Domain/BaseLiner/BaseLineImporter.php": {
+      "errors": 1,
+      "messages": [
+        {
+          "message": "Parameter #1 $array of static method DaveLiddament\\StaticAnalysisResultsBaseliner\\Domain\\ResultsParser\\AnalysisResults::fromArray() expects int, array given.",
+          "line": 89,
+          "ignorable": true,
+          "identifier": "argument.type",
+          "relativePath": "Domain/BaseLiner/BaseLineImporter.php"
+        }
+      ]
+    },
+    "/vagrant/static-analysis-baseliner/src/Domain/ResultsParser/AnalysisResults.php": {
+      "errors": 2,
+      "messages": [
+        {
+          "message": "PHPDoc tag @param for parameter $array with type array is incompatible with native type int",
+          "line": 73,
+          "ignorable": true,
+          "identifier": "parameter.phpDocType",
+          "relativePath": "Domain/ResultsParser/AnalysisResults.php"
+        },
+        {
+          "message": "Argument of an invalid type int supplied for foreach, only iterables are supported.",
+          "line": null,
+          "ignorable": true,
+          "identifier": "foreach.nonIterable",
+          "relativePath": "Domain/ResultsParser/AnalysisResults.php"
+        }
+      ]
+    }
+  },
+  "errors": []
+}


### PR DESCRIPTION
PHPStan (1.11+) attaches an identifier (e.g. argument.type) to each error. When present SARB now uses it as the violation type instead of guessing the type from the message. This makes baselines robust against PHPStan rewording messages between releases.

- Baselines record an optional typesFromToolIdentifiers marker.
- Results with identifiers still match baselines created before identifiers were available (via the legacy guessed type); SARB recommends regenerating the baseline.
- Using an identifier based baseline with results that contain no identifiers fails with exit code 17.
- The type guessing warning is no longer shown when every result carried an identifier.
- The table and github output formats now include the violation type.