### PR TITLE
Fix git diff handling for non-default git configurations

### DIFF
--- a/src/Domain/HistoryAnalyser/UnifiedDiffParser/internal/ChangeHunkParserState.php
+++ b/src/Domain/HistoryAnalyser/UnifiedDiffParser/internal/ChangeHunkParserState.php
@@ -53,6 +53,11 @@ final class ChangeHunkParserState implements State
             return $this->processNewChangeHunk($line);
         }
 
+        if (StringUtils::startsWith('\\', $line)) {
+            // Metadata (e.g. "\ No newline at end of file"), not a line of the file
+            return $this;
+        }
+
         if (StringUtils::startsWith('+', $line)) {
             $this->processAddLine();
 

--- a/src/Domain/HistoryAnalyser/UnifiedDiffParser/internal/DiffParseException.php
+++ b/src/Domain/HistoryAnalyser/UnifiedDiffParser/internal/DiffParseException.php
@@ -29,6 +29,11 @@ final class DiffParseException extends \Exception
         return new self('RANGE_INFORMATION_PARSE_ERROR', $rangeInformation);
     }
 
+    public static function unrecognisedFileDiffFormat(string $line): self
+    {
+        return new self('UNRECOGNISED_FILE_DIFF_FORMAT', $line);
+    }
+
     /**
      * @var string
      */

--- a/src/Domain/HistoryAnalyser/UnifiedDiffParser/internal/FindOriginalFileNameState.php
+++ b/src/Domain/HistoryAnalyser/UnifiedDiffParser/internal/FindOriginalFileNameState.php
@@ -45,6 +45,13 @@ final class FindOriginalFileNameState implements State
             return $this->processAsChange($line);
         }
 
+        // A change hunk can only appear after the file names. Reaching one whilst still looking
+        // for the original file name means the diff is in a format that was not recognised
+        // (e.g. quoted paths or non standard prefixes). Fail rather than silently skip the file.
+        if (LineTypeDetector::isStartOfChangeHunk($line)) {
+            throw DiffParseException::unrecognisedFileDiffFormat($line);
+        }
+
         return $this;
     }
 

--- a/src/Plugins/GitDiffHistoryAnalyser/GitCommit.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/GitCommit.php
@@ -38,9 +38,11 @@ final class GitCommit implements HistoryMarker
 
     /**
      * Validates the string provided could be a valid git SHA.
+     *
+     * Both SHA-1 (40 characters) and SHA-256 (64 characters) object formats are supported.
      */
     public static function validateGitSha(string $gitSha): bool
     {
-        return 1 === preg_match('/^[0-9a-f]{40}$/', $gitSha);
+        return 1 === preg_match('/^([0-9a-f]{40}|[0-9a-f]{64})$/', $gitSha);
     }
 }

--- a/src/Plugins/GitDiffHistoryAnalyser/internal/GitCliWrapper.php
+++ b/src/Plugins/GitDiffHistoryAnalyser/internal/GitCliWrapper.php
@@ -37,8 +37,18 @@ final class GitCliWrapper implements GitWrapper
 
     public function getGitDiff(ProjectRoot $projectRoot, GitCommit $originalCommit): string
     {
+        // Pin the diff output format. The parser relies on "--- a/" and "+++ b/" prefixes and
+        // unquoted paths, all of which users can change via their git configuration
+        // (e.g. diff.noprefix, diff.mnemonicPrefix, core.quotePath).
         $arguments = [
+            '-c', 'core.quotePath=false',
+            '-c', 'diff.noprefix=false',
+            '-c', 'diff.mnemonicPrefix=false',
+            '-c', 'diff.srcPrefix=a/',
+            '-c', 'diff.dstPrefix=b/',
             'diff',
+            '--no-color',
+            '--no-ext-diff',
             '-w',
             '-M',
             '-l0',

--- a/tests/Integration/GitCliWrapperTest.php
+++ b/tests/Integration/GitCliWrapperTest.php
@@ -4,10 +4,13 @@ namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Integration;
 
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\RelativeFileName;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\HistoryAnalyser\UnifiedDiffParser\NewFileName;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\HistoryAnalyser\UnifiedDiffParser\Parser;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\GitDiffHistoryAnalyser\internal\GitCliWrapper;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 final class GitCliWrapperTest extends TestCase
 {
@@ -90,6 +93,40 @@ final class GitCliWrapperTest extends TestCase
         $this->gitWrapper->addAll($this->projectRoot);
 
         $this->assertNotClean();
+    }
+
+    public function testDiffFormatNotAffectedByUserGitConfiguration(): void
+    {
+        // Git configuration options that alter the format of git diff output
+        $this->setGitConfig('diff.noprefix', 'true');
+        $this->setGitConfig('diff.mnemonicPrefix', 'true');
+        $this->setGitConfig('core.quotePath', 'true');
+
+        // Non ASCII filename (quoted by git diff when core.quotePath is true)
+        $relativeFileName = new RelativeFileName('café.txt');
+        $absoluteFileName = $this->projectRoot->getAbsoluteFileName($relativeFileName);
+
+        $this->fileSystem->dumpFile($absoluteFileName->getFileName(), "line1\nline2\n");
+        $this->gitWrapper->addAndCommit('Add file', $this->projectRoot);
+        $gitCommit = $this->gitWrapper->getCurrentSha($this->projectRoot);
+
+        $this->fileSystem->dumpFile($absoluteFileName->getFileName(), "line0\nline1\nline2\n");
+
+        $diffAsString = $this->gitWrapper->getGitDiff($this->projectRoot, $gitCommit);
+        $fileMutations = (new Parser())->parseDiff($diffAsString);
+
+        Assert::assertNotNull(
+            $fileMutations->getFileMutation(new NewFileName('café.txt')),
+            "No FileMutation found. Diff was:\n$diffAsString",
+        );
+        $this->removeTestDirectory();
+    }
+
+    private function setGitConfig(string $key, string $value): void
+    {
+        $process = new Process(['git', "--git-dir={$this->projectRoot}/.git", 'config', $key, $value]);
+        $process->run();
+        Assert::assertTrue($process->isSuccessful(), $process->getErrorOutput());
     }
 
     public function assertNotClean(): void

--- a/tests/Unit/Core/HistoryAnalyser/UnifiedDiffParser/DiffParserTest.php
+++ b/tests/Unit/Core/HistoryAnalyser/UnifiedDiffParser/DiffParserTest.php
@@ -228,6 +228,23 @@ final class DiffParserTest extends TestCase
                     ],
                 ],
             ],
+            'noNewlineAtEndOfFile' => [
+                'noNewlineAtEndOfFile.diff',
+                [
+                    [
+                        new OriginalFileName('message.txt'),
+                        new NewFileName('message.txt'),
+                        false,
+                        false,
+                        [
+                            // The "\ No newline at end of file" marker must not be counted as a line
+                            LineMutation::newLineNumber(new LineNumber(1)),
+                            LineMutation::originalLineNumber(new LineNumber(3)),
+                            LineMutation::newLineNumber(new LineNumber(4)),
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/tests/Unit/Core/HistoryAnalyser/UnifiedDiffParser/InvalidDiffParserTest.php
+++ b/tests/Unit/Core/HistoryAnalyser/UnifiedDiffParser/InvalidDiffParserTest.php
@@ -35,6 +35,24 @@ final class InvalidDiffParserTest extends TestCase
                 ParseException::UNEXPECTED_END_OF_FILE,
                 'NO_NEW_FILE_NAME',
             ],
+
+            'noPrefix' => [
+                'noPrefix.diff',
+                '5',
+                'UNRECOGNISED_FILE_DIFF_FORMAT',
+            ],
+
+            'mnemonicPrefix' => [
+                'mnemonicPrefix.diff',
+                '5',
+                'UNRECOGNISED_FILE_DIFF_FORMAT',
+            ],
+
+            'quotedFileNames' => [
+                'quotedFileNames.diff',
+                '5',
+                'UNRECOGNISED_FILE_DIFF_FORMAT',
+            ],
         ];
     }
 

--- a/tests/Unit/Plugins/GitDiffHistoryAnalyser/GitCommitTest.php
+++ b/tests/Unit/Plugins/GitDiffHistoryAnalyser/GitCommitTest.php
@@ -26,6 +26,14 @@ final class GitCommitTest extends TestCase
             'invalidCharacters' => [
                 '43462550d5644312b6757bb89ac85aa8d9590c2x',
             ],
+
+            'sha256TooShort' => [
+                'dccf9c8b8f2977cea0c1a1474d20531d9482a1c825b1a0d55163d54e29a3343',
+            ],
+
+            'sha256TooLong' => [
+                'dccf9c8b8f2977cea0c1a1474d20531d9482a1c825b1a0d55163d54e29a3343a1',
+            ],
         ];
     }
 
@@ -53,6 +61,10 @@ final class GitCommitTest extends TestCase
             ],
             [
                 '30b68f53df4e590657ba5184b1c6013e9a8dad5c',
+            ],
+            [
+                // SHA-256 object format
+                'dccf9c8b8f2977cea0c1a1474d20531d9482a1c825b1a0d55163d54e29a3343a',
             ],
         ];
     }

--- a/tests/resources/invalidDiffs/mnemonicPrefix.diff
+++ b/tests/resources/invalidDiffs/mnemonicPrefix.diff
@@ -1,0 +1,10 @@
+diff --git c/src/Person.php w/src/Person.php
+index 81ee914..a7005b2 100644
+--- c/src/Person.php
++++ w/src/Person.php
+@@ -15,6 +15,7 @@ class Person
+     private $name;
+
+     /**
++     * @var bool
+      */

--- a/tests/resources/invalidDiffs/noPrefix.diff
+++ b/tests/resources/invalidDiffs/noPrefix.diff
@@ -1,0 +1,10 @@
+diff --git src/Person.php src/Person.php
+index 81ee914..a7005b2 100644
+--- src/Person.php
++++ src/Person.php
+@@ -15,6 +15,7 @@ class Person
+     private $name;
+
+     /**
++     * @var bool
+      */

--- a/tests/resources/invalidDiffs/quotedFileNames.diff
+++ b/tests/resources/invalidDiffs/quotedFileNames.diff
@@ -1,0 +1,10 @@
+diff --git "a/src/Caf\303\251.php" "b/src/Caf\303\251.php"
+index 81ee914..a7005b2 100644
+--- "a/src/Caf\303\251.php"
++++ "b/src/Caf\303\251.php"
+@@ -15,6 +15,7 @@ class Person
+     private $name;
+
+     /**
++     * @var bool
+      */

--- a/tests/resources/validDiffs/noNewlineAtEndOfFile.diff
+++ b/tests/resources/validDiffs/noNewlineAtEndOfFile.diff
@@ -1,0 +1,11 @@
+diff --git a/message.txt b/message.txt
+index 1d609b1..8b56441 100644
+--- a/message.txt
++++ b/message.txt
+@@ -1,3 +1,4 @@
++lineNEW
+ line1
+ line2
+-last
+\ No newline at end of file
++lastCHANGED


### PR DESCRIPTION
## Problem

The unified diff parser relies on the exact output format git produces with default configuration (`--- a/` / `+++ b/` prefixes, unquoted paths), and **silently skips anything it doesn't recognise**. That combination meant several common situations produced wrong results with no error:

- `diff.noprefix=true` or `diff.mnemonicPrefix=true` in the user's `~/.gitconfig`: every file diff is dropped.
- The default `core.quotePath=true`: any file with a non-ASCII path (`café.php`) is emitted C-quoted and dropped.
- `color.diff=always` / external diff drivers: same failure mode.

A dropped file diff means SARB falls back to identity line-mapping for that file, so after any edit, baselined issues resurface as "new" and genuinely new issues at stale line numbers are silently suppressed.

Separately, git repos created with `--object-format=sha256` crashed with "Unexpected critical error" + stack trace (exit 100), because the SHA validation only accepted 40-hex.

## Fix (belt and braces)

1. **Pin the diff format** when invoking git: `-c core.quotePath=false -c diff.noprefix=false -c diff.mnemonicPrefix=false -c diff.srcPrefix=a/ -c diff.dstPrefix=b/ diff --no-color --no-ext-diff ...` (unknown config keys are ignored by older git, so `diff.srcPrefix`/`dstPrefix` — git 2.45+ — are safe to pass).
2. **Fail loudly on format drift**: reaching a `@@` change hunk while still looking for the original file name now throws `UNRECOGNISED_FILE_DIFF_FORMAT` (surfaced as the usual history-analyser error, exit 15) instead of silently skipping the file. Binary-file entries keep their legitimate silent skip (they have no hunks).
3. **Ignore `\ No newline at end of file` markers** — previously counted as context lines, producing phantom mappings just past EOF (benign in every scenario we could construct, but wrong).
4. **Accept SHA-256 hashes** (40- or 64-char hex) in `GitCommit`.

## Testing

- New invalid-diff fixtures (noprefix / mnemonic prefix / quoted paths) asserting the parser now fails loudly with the exact line number.
- New valid-diff fixture covering the no-newline marker with exact expected line mutations.
- New integration test that sets `diff.noprefix`, `diff.mnemonicPrefix` and `core.quotePath` in a real repo config, commits a `café.txt`, and verifies the diff SARB obtains still parses correctly (fails without the `-c` pinning).
- SHA-256 valid/invalid cases in `GitCommitTest`.
- Full `composer ci` passes (100% coverage, PHPStan max, cs-fixer).