### PR TITLE
Fix git history tracking when using --relative-path-to-code

### DIFF
--- a/src/Domain/Common/Location.php
+++ b/src/Domain/Common/Location.php
@@ -26,6 +26,11 @@ final class Location
     }
 
     /**
+     * NOTE: $relativeFileName is relative to the directory holding the code being analysed
+     * (which is the project root unless --relative-path-to-code is used). The Location's
+     * relative file name is always relative to the project root, so that it uses the same
+     * coordinate system as the git diff based history analyser and the baseline.
+     *
      * @throws InvalidPathException
      */
     public static function fromRelativeFileName(
@@ -35,7 +40,7 @@ final class Location
     ): self {
         $absoluteFileName = $projectRoot->getAbsoluteFileName($relativeFileName);
 
-        return new self($absoluteFileName, $relativeFileName, $lineNumber);
+        return new self($absoluteFileName, $projectRoot->prependRelativePath($relativeFileName), $lineNumber);
     }
 
     private function __construct(

--- a/src/Domain/Common/ProjectRoot.php
+++ b/src/Domain/Common/ProjectRoot.php
@@ -17,11 +17,6 @@ use Webmozart\Assert\Assert;
 final class ProjectRoot implements \Stringable
 {
     /**
-     * @var string
-     */
-    private $relativePath = '';
-
-    /**
      * @throws InvalidPathException
      */
     public static function fromCurrentWorkingDirectory(string $currentWorkingDirectory): self
@@ -48,6 +43,7 @@ final class ProjectRoot implements \Stringable
 
     private function __construct(
         private string $rootDirectory,
+        private string $relativePath = '',
     ) {
     }
 
@@ -56,10 +52,22 @@ final class ProjectRoot implements \Stringable
      */
     public function withRelativePath(string $relativePath): self
     {
-        $projectRoot = new self($this->rootDirectory);
-        $projectRoot->relativePath = $relativePath;
+        return new self($this->rootDirectory, $relativePath);
+    }
 
-        return $projectRoot;
+    /**
+     * Converts a path relative to the directory holding the code being analysed into a path
+     * relative to the project root.
+     *
+     * These are the same unless a relativePath is configured (the --relative-path-to-code option).
+     */
+    public function prependRelativePath(RelativeFileName $relativeFileName): RelativeFileName
+    {
+        if ('' === $this->relativePath) {
+            return $relativeFileName;
+        }
+
+        return new RelativeFileName(Path::join([$this->relativePath, $relativeFileName->getFileName()]));
     }
 
     /**

--- a/tests/Integration/RelativePathEndToEndTest.php
+++ b/tests/Integration/RelativePathEndToEndTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Integration;
+
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\RelativeFileName;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Command\CreateBaseLineCommand;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Command\RemoveBaseLineFromResultsCommand;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Container\Container;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\GitDiffHistoryAnalyser\internal\GitCliWrapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * End to end test of using --relative-path-to-code with a results parser that supplies
+ * relative paths. The git history tracking must map the tool relative file names on to
+ * the project root relative names held in the git diff.
+ */
+final class RelativePathEndToEndTest extends TestCase
+{
+    use TestDirectoryTrait;
+
+    private const RELATIVE_PATH_TO_CODE = 'code';
+    private const ANALYSED_FILE = 'src/Widget.php';
+    private const TYPE = 'SomeType';
+
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var GitCliWrapper
+     */
+    private $gitWrapper;
+
+    /**
+     * @var ProjectRoot
+     */
+    private $projectRoot;
+
+    /**
+     * @var Application
+     */
+    private $application;
+
+    protected function setUp(): void
+    {
+        $this->fileSystem = new Filesystem();
+        $this->gitWrapper = new GitCliWrapper();
+        $container = new Container();
+        $this->application = $container->getApplication();
+    }
+
+    public function testHistoryTrackedForRelativePathResults(): void
+    {
+        $this->createTestDirectory();
+        $this->gitWrapper->init($this->projectRoot);
+
+        // Code lives in a sub directory of the project (git) root
+        $analysedFile = self::RELATIVE_PATH_TO_CODE.'/'.self::ANALYSED_FILE;
+        $this->writeFile($analysedFile, "line1\nline2\nline3\nline4\nline5\n");
+        $this->gitWrapper->addAndCommit('Commit 1', $this->projectRoot);
+
+        // Baseline an issue at line 3 (results are relative to the code directory)
+        $this->runCommand(
+            CreateBaseLineCommand::COMMAND_NAME,
+            [
+                '--input-format' => 'sarb-relative-json',
+                '--relative-path-to-code' => self::RELATIVE_PATH_TO_CODE,
+                '--project-root' => (string) $this->projectRoot,
+                'baseline-file' => $this->getBaselineFilePath(),
+            ],
+            0,
+            $this->createResults(3),
+        );
+
+        // Insert 2 lines above the baselined issue. The issue is now reported at line 5.
+        $this->writeFile($analysedFile, "new1\nnew2\nline1\nline2\nline3\nline4\nline5\n");
+
+        $output = $this->runCommand(
+            RemoveBaseLineFromResultsCommand::COMMAND_NAME,
+            [
+                '--output-format' => 'json',
+                '--relative-path-to-code' => self::RELATIVE_PATH_TO_CODE,
+                '--project-root' => (string) $this->projectRoot,
+                'baseline-file' => $this->getBaselineFilePath(),
+            ],
+            0,
+            $this->createResults(5),
+        );
+
+        // The baselined issue must be recognised via the git history despite the line shift
+        $this->assertStringContainsString('Issue count with baseline removed: 0', $output);
+
+        // Only delete test directory if tests passed. Keep to investigate test failures
+        $this->removeTestDirectory();
+    }
+
+    private function createResults(int $lineNumber): string
+    {
+        $results = [
+            [
+                'line' => $lineNumber,
+                'type' => self::TYPE,
+                'message' => 'MESSAGE',
+                'relative_path' => self::ANALYSED_FILE,
+            ],
+        ];
+
+        $asString = json_encode($results);
+        $this->assertNotFalse($asString);
+
+        return $asString;
+    }
+
+    private function writeFile(string $relativeFileName, string $contents): void
+    {
+        $absoluteFileName = $this->projectRoot->getAbsoluteFileName(new RelativeFileName($relativeFileName));
+        $this->fileSystem->dumpFile($absoluteFileName->getFileName(), $contents);
+    }
+
+    /**
+     * @param array<string, string|null> $arguments
+     */
+    private function runCommand(
+        string $commandName,
+        array $arguments,
+        int $expectedExitCode,
+        string $stdin,
+    ): string {
+        $command = $this->application->find($commandName);
+        $commandTester = new CommandTester($command);
+        $arguments['command'] = $command->getName();
+
+        $commandTester->setInputs([$stdin]);
+
+        $actualExitCode = $commandTester->execute($arguments);
+        $output = $commandTester->getDisplay();
+        $this->assertSame($expectedExitCode, $actualExitCode, $output);
+
+        return $output;
+    }
+
+    private function getBaselineFilePath(): string
+    {
+        return "{$this->projectRoot}/baseline.json";
+    }
+}

--- a/tests/Unit/Core/Common/LocationTest.php
+++ b/tests/Unit/Core/Common/LocationTest.php
@@ -47,7 +47,9 @@ final class LocationTest extends TestCase
         $location = Location::fromRelativeFileName($relativeFileName, $projectRoot, $lineNumber);
 
         $this->assertSame($lineNumber, $location->getLineNumber());
-        $this->assertSame('src/File.php', $location->getRelativeFileName()->getFileName());
+        // The Location's relative file name is relative to the project root (not the code directory),
+        // so that it matches the paths in git diff output.
+        $this->assertSame('code/src/File.php', $location->getRelativeFileName()->getFileName());
         $this->assertSame('/sarb/root/code/src/File.php', $location->getAbsoluteFileName()->getFileName());
     }
 }

--- a/tests/Unit/Plugins/ResultsParsers/PhanJsonResultsParser/PhanJsonResultsParserTest.php
+++ b/tests/Unit/Plugins/ResultsParsers/PhanJsonResultsParser/PhanJsonResultsParserTest.php
@@ -79,8 +79,10 @@ final class PhanJsonResultsParserTest extends TestCase
         $result1 = $analysisResults->getAnalysisResults()[0];
         $result2 = $analysisResults->getAnalysisResults()[1];
 
+        // The relative file names are relative to the project root (not the code directory),
+        // so that they match the paths in git diff output.
         $this->assertMatch($result1,
-            'src/Domain/Analyser/BaseLineResultsRemover.php',
+            'code/src/Domain/Analyser/BaseLineResultsRemover.php',
             16,
             'PhanUnreferencedUseNormal',
             Severity::error());
@@ -94,7 +96,7 @@ final class PhanJsonResultsParserTest extends TestCase
         );
 
         $this->assertMatch($result2,
-            'src/Plugins/PsalmJsonResultsParser/PsalmJsonResultsParser.php',
+            'code/src/Plugins/PsalmJsonResultsParser/PsalmJsonResultsParser.php',
             107,
             'PhanPossiblyNullTypeArgument',
             Severity::error());

--- a/tests/Unit/Plugins/ResultsParsers/SarbJsonResultsParser/SarbRelativeFileJsonResultsParserTest.php
+++ b/tests/Unit/Plugins/ResultsParsers/SarbJsonResultsParser/SarbRelativeFileJsonResultsParserTest.php
@@ -93,8 +93,10 @@ final class SarbRelativeFileJsonResultsParserTest extends TestCase
         $result2 = $this->analysisResults->getAnalysisResults()[1];
         $result3 = $this->analysisResults->getAnalysisResults()[2];
 
+        // The relative file names are relative to the project root (not the code directory),
+        // so that they match the paths in git diff output.
         $this->assertMatch($result1,
-            'src/Domain/ResultsParser/AnalysisResults.php',
+            'code/src/Domain/ResultsParser/AnalysisResults.php',
             67,
             'MismatchingDocblockParamType',
             Severity::error(),
@@ -109,14 +111,14 @@ final class SarbRelativeFileJsonResultsParserTest extends TestCase
         );
 
         $this->assertMatch($result2,
-            'src/Domain/Utils/JsonUtils.php',
+            'code/src/Domain/Utils/JsonUtils.php',
             29,
             'MixedAssignment',
             Severity::error(),
         );
 
         $this->assertMatch($result3,
-            'src/Plugins/PsalmJsonResultsParser/PsalmJsonResultsParser.php',
+            'code/src/Plugins/PsalmJsonResultsParser/PsalmJsonResultsParser.php',
             90,
             'MixedAssignment',
             Severity::warning(),


### PR DESCRIPTION
## Problem

Results parsers that supply relative paths (`phan-json`, `sarb-relative-json`, `phpmnd`) keep the tool's file name, which is relative to the **directory holding the analysed code**. Git diff paths are relative to the **project root**. With `--relative-path-to-code=backend`, the baseline stored `src/File.php` while the diff mutations were keyed `backend/src/File.php` — the lookup never matched, so the history analyser silently fell back to identity line mapping. Consequences:

- Insert a line above a baselined issue → the issue resurfaces as "new".
- Renames were untracked for these files.
- (Absolute-path parsers were unaffected: their relative names are already project-root-relative.)

## Fix

`Location::fromRelativeFileName()` now stores the file name **relative to the project root** (the tool-relative name prefixed with the relative path to the code, via a new `ProjectRoot::prependRelativePath()`). Everything downstream — baseline content, history lookup, output — then shares one coordinate system. `ProjectRoot::withRelativePath()` was also made properly immutable (constructor field instead of mutating a clone).

## Behaviour notes

- Without `--relative-path-to-code`, nothing changes.
- Output formatters now show the project-root-relative name for these parsers (e.g. `code/src/File.php`), which also makes `github` annotations resolve correctly.
- **Baselines previously created with `--relative-path-to-code` + a relative-path parser need regenerating** — they store unprefixed names. History tracking never actually worked for that combination, so those baselines were already broken in a worse way (silent resurfacing on every edit).

## Testing

- `LocationTest` + both relative-path parser tests updated to the new coordinate system.
- New `RelativePathEndToEndTest`: real git repo with code under `code/`, baseline an issue via `sarb-relative-json` + `--relative-path-to-code`, insert two lines above it, and assert the shifted issue is still recognised as baselined (fails without this fix).
- Full `composer ci` passes (100% coverage, PHPStan max, cs-fixer).