### PR TITLE
Harden error handling for invalid input

### DIFF
--- a/src/Domain/BaseLiner/BaseLineAnalysisResult.php
+++ b/src/Domain/BaseLiner/BaseLineAnalysisResult.php
@@ -9,6 +9,7 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Type;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\ArrayParseException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\ArrayUtils;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\SeverityReader;
 
 final class BaseLineAnalysisResult
 {
@@ -25,10 +26,17 @@ final class BaseLineAnalysisResult
      */
     public static function fromArray(array $array): self
     {
-        $lineNumber = new LineNumber(ArrayUtils::getIntValue($array, self::LINE_NUMBER));
+        // Validate values before constructing value objects, so that invalid data in a baseline
+        // file surfaces as a parse error rather than an unexpected critical error.
+        $lineNumberAsInt = ArrayUtils::getIntValue($array, self::LINE_NUMBER);
+        if ($lineNumberAsInt < 0) {
+            throw ArrayParseException::invalidValue(self::LINE_NUMBER, (string) $lineNumberAsInt);
+        }
+
+        $lineNumber = new LineNumber($lineNumberAsInt);
         $fileName = new RelativeFileName(ArrayUtils::getStringValue($array, self::FILE_NAME));
         $type = new Type(ArrayUtils::getStringValue($array, self::TYPE));
-        $severity = Severity::fromStringOrNull(ArrayUtils::getOptionalStringValue($array, self::SEVERITY));
+        $severity = SeverityReader::getOptionalSeverity($array, self::SEVERITY);
         $message = ArrayUtils::getStringValue($array, self::MESSAGE);
 
         return new self($fileName, $lineNumber, $type, $message, $severity);

--- a/src/Domain/BaseLiner/BaseLineImportException.php
+++ b/src/Domain/BaseLiner/BaseLineImportException.php
@@ -13,7 +13,7 @@ final class BaseLineImportException extends SarbException
     public static function fromException(BaseLineFileName $baseLineFile, \Exception $e): self
     {
         $message = <<<EOF
-Failed to import baseline file [{$baseLineFile->getFileName()}]. Is this a valid baseline file?.
+Failed to import baseline file [{$baseLineFile->getFileName()}]. Is this a valid baseline file?
 {$e->getMessage()}
 EOF;
 

--- a/src/Domain/HistoryAnalyser/UnifiedDiffParser/FileMutations.php
+++ b/src/Domain/HistoryAnalyser/UnifiedDiffParser/FileMutations.php
@@ -13,7 +13,7 @@ namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\HistoryAnalyser\Un
 use Webmozart\Assert\Assert;
 
 /**
- * Holds FileMutation objects. Use the.
+ * Holds FileMutation objects, keyed by new file name.
  */
 final class FileMutations
 {

--- a/src/Domain/ResultsParser/AnalysisResultsImportException.php
+++ b/src/Domain/ResultsParser/AnalysisResultsImportException.php
@@ -12,7 +12,7 @@ final class AnalysisResultsImportException extends SarbException
     public static function fromException(Identifier $identifier, \Exception $e): self
     {
         $message = <<<EOF
-Failed to parse analysis results. Have you supplied the data for format [{$identifier->getCode()}].
+Failed to parse analysis results. Have you supplied the data for format [{$identifier->getCode()}]?
 {$e->getMessage()}
 EOF;
 

--- a/src/Domain/Utils/JsonUtils.php
+++ b/src/Domain/Utils/JsonUtils.php
@@ -10,6 +10,7 @@
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils;
 
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\SarbException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\File\InvalidContentTypeException;
 
 final class JsonUtils
@@ -35,13 +36,18 @@ final class JsonUtils
     /**
      * Converts array to a JSON representation in a string.
      *
+     * NOTE: invalid UTF-8 byte sequences (which some static analysis tools can emit in messages)
+     * are replaced with the Unicode substitution character rather than failing.
+     *
      * @param array<mixed> $data
+     *
+     * @throws SarbException
      */
     public static function toString(array $data): string
     {
-        $asString = json_encode($data, \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
+        $asString = json_encode($data, \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT | \JSON_INVALID_UTF8_SUBSTITUTE);
         if (false === $asString) {
-            throw new \LogicException('Can not convert data to JSON string');
+            throw new SarbException('Can not convert data to JSON string');
         }
 
         return $asString;

--- a/src/Framework/Command/internal/CliConfigReader.php
+++ b/src/Framework/Command/internal/CliConfigReader.php
@@ -48,8 +48,18 @@ final class CliConfigReader
         // If testing this will get input added by `CommandTester::setInputs` method.
         $inputSteam = ($input instanceof StreamableInputInterface) ? $input->getStream() : null;
 
-        // If nothing from input stream use STDIN instead.
-        $inputSteam ??= \STDIN;
+        if (null === $inputSteam) {
+            // @codeCoverageIgnoreStart
+            // Not possible to cover in tests: CommandTester always supplies an input stream.
+            // Reading STDIN from an interactive terminal would block forever waiting for input.
+            if (stream_isatty(\STDIN)) {
+                throw new SarbException('No static analysis results provided. Pipe the output of the static analysis tool into sarb.');
+            }
+
+            // If nothing from input stream use STDIN instead.
+            $inputSteam = \STDIN;
+            // @codeCoverageIgnoreEnd
+        }
 
         $input = stream_get_contents($inputSteam);
 

--- a/src/Framework/Command/internal/ErrorReporter.php
+++ b/src/Framework/Command/internal/ErrorReporter.php
@@ -40,6 +40,10 @@ final class ErrorReporter
             OutputWriter::writeToStdError($output, $e->getMessage(), true);
 
             return 16;
+        } catch (SarbException $e) {
+            OutputWriter::writeToStdError($output, $e->getMessage(), true);
+
+            return 18;
         } catch (\Throwable $e) {
             // This should never happen. All exceptions should extend SarbException
             OutputWriter::writeToStdError($output, "Unexpected critical error: {$e->getMessage()}", true);

--- a/tests/Unit/Core/BaseLiner/BaseLineAnalysisResultTest.php
+++ b/tests/Unit/Core/BaseLiner/BaseLineAnalysisResultTest.php
@@ -147,6 +147,23 @@ final class BaseLineAnalysisResultTest extends TestCase
                     'type' => self::TYPE_1,
                 ],
             ],
+            'negativeLineNumber' => [
+                [
+                    'lineNumber' => -1,
+                    'fileName' => self::FILE_NAME_1,
+                    'type' => self::TYPE_1,
+                    'message' => self::MESSAGE_1,
+                ],
+            ],
+            'invalidSeverity' => [
+                [
+                    'lineNumber' => self::LINE_NUMBER_1,
+                    'fileName' => self::FILE_NAME_1,
+                    'type' => self::TYPE_1,
+                    'message' => self::MESSAGE_1,
+                    'severity' => 'rubbish',
+                ],
+            ],
         ];
     }
 
@@ -158,6 +175,19 @@ final class BaseLineAnalysisResultTest extends TestCase
     {
         $this->expectException(ArrayParseException::class);
         BaseLineAnalysisResult::fromArray($asArray);
+    }
+
+    public function testSeverityIsCaseInsensitive(): void
+    {
+        $baseLineAnalysisResult = BaseLineAnalysisResult::fromArray([
+            'lineNumber' => self::LINE_NUMBER_1,
+            'fileName' => self::FILE_NAME_1,
+            'type' => self::TYPE_1,
+            'message' => self::MESSAGE_1,
+            'severity' => 'Warning',
+        ]);
+
+        $this->assertTrue($baseLineAnalysisResult->getSeverity()->isWarning());
     }
 
     private function createBaseLineResult(): BaseLineAnalysisResult

--- a/tests/Unit/Core/BaseLiner/BaseLineImporterTest.php
+++ b/tests/Unit/Core/BaseLiner/BaseLineImporterTest.php
@@ -67,6 +67,7 @@ final class BaseLineImporterTest extends TestCase
             ['baseline/invalid-results-parser.json'],
             ['baseline/invalid-history-analyser.json'],
             ['baseline/invalid-history-marker.json'],
+            ['baseline/invalid-negative-line-number.json'],
         ];
     }
 

--- a/tests/Unit/Core/Common/SeverityTest.php
+++ b/tests/Unit/Core/Common/SeverityTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Core\Common;
+
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
+use PHPUnit\Framework\TestCase;
+
+final class SeverityTest extends TestCase
+{
+    public function testError(): void
+    {
+        $severity = Severity::error();
+        $this->assertSame('error', $severity->getSeverity());
+        $this->assertFalse($severity->isWarning());
+    }
+
+    public function testWarning(): void
+    {
+        $severity = Severity::warning();
+        $this->assertSame('warning', $severity->getSeverity());
+        $this->assertTrue($severity->isWarning());
+    }
+
+    public function testFromStringOrNullDefaultsToError(): void
+    {
+        $severity = Severity::fromStringOrNull(null);
+        $this->assertSame('error', $severity->getSeverity());
+    }
+
+    public function testFromString(): void
+    {
+        $severity = Severity::fromStringOrNull('warning');
+        $this->assertSame('warning', $severity->getSeverity());
+    }
+
+    public function testIsValueValid(): void
+    {
+        $this->assertTrue(Severity::isValueValid('error'));
+        $this->assertTrue(Severity::isValueValid('warning'));
+        $this->assertFalse(Severity::isValueValid('rubbish'));
+    }
+}

--- a/tests/Unit/Core/Utils/JsonUtilsTest.php
+++ b/tests/Unit/Core/Utils/JsonUtilsTest.php
@@ -2,6 +2,7 @@
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Core\Utils;
 
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\SarbException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\File\InvalidContentTypeException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\JsonUtils;
 use PHPUnit\Framework\TestCase;
@@ -41,9 +42,19 @@ EOF;
 
     public function testToStringInvalidData(): void
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(SarbException::class);
         JsonUtils::toString([
             \INF,
         ]);
+    }
+
+    public function testToStringSubstitutesInvalidUtf8(): void
+    {
+        // \xE9 is é in ISO-8859-1; it is not valid UTF-8
+        $output = JsonUtils::toString([
+            'message' => "caf\xE9",
+        ]);
+
+        $this->assertSame("{\n    \"message\": \"caf\u{FFFD}\"\n}", $output);
     }
 }

--- a/tests/Unit/Framework/Command/RemoveBaseLineCommandTest.php
+++ b/tests/Unit/Framework/Command/RemoveBaseLineCommandTest.php
@@ -7,6 +7,7 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\BaseLine;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\LineNumber;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Location;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\SarbException;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Type;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\OutputFormatter\OutputFormatter;
@@ -195,6 +196,22 @@ EOF;
         ]);
 
         $this->assertReturnCode(100, $commandTester);
+    }
+
+    public function testSarbException(): void
+    {
+        $commandTester = $this->createCommandTester(
+            $this->getAnalysisResultsWithXResults(1),
+            null,
+            new SarbException('Something went wrong'),
+        );
+
+        $commandTester->execute([
+            self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
+        ]);
+
+        $this->assertReturnCode(18, $commandTester);
+        $this->assertResponseContains('Something went wrong', $commandTester);
     }
 
     public function testCleanUpOptions(): void

--- a/tests/resources/baseline/invalid-negative-line-number.json
+++ b/tests/resources/baseline/invalid-negative-line-number.json
@@ -1,0 +1,14 @@
+{
+  "historyMarker": "9be6101dc6848d67b5958a5762494060062e42ec",
+  "historyAnalyser": "git",
+  "resultsParser": "sarb-json",
+  "analysisResults": [
+    {
+      "lineNumber": -10,
+      "fileName": "FILE_1",
+      "type": "TYPE_1",
+      "message": "MESSAGE_1",
+      "severity": "error"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Several error paths escaped SARB's clean exception→exit-code mapping and surfaced as "Unexpected critical error" + a stack trace (exit 100):

- A hand-edited or merge-mangled baseline with `"severity": "Warning"` (capitalised) or a negative `lineNumber` — the Webmozart asserts inside `LineNumber`/`Severity` aren't `ArrayParseException`s, so they escaped `BaseLineImporter`'s catch list.
- `ErrorReporter`'s catch-all comments *"This should never happen. All exceptions should extend SarbException"* — but base `SarbException` itself was never caught, and several real paths throw it (stdin read failure, missing simplexml in the JUnit formatter, project-root helpers).
- Running `sarb create baseline.json` interactively (no pipe) blocked forever on stdin with no explanation.
- `json_encode` failure on invalid UTF-8 in tool messages threw a raw `LogicException`.

## Fix

- `BaseLineAnalysisResult::fromArray()` validates line number and severity up front, throwing `ArrayParseException` → clean "Failed to import baseline file" (exit 12). Severity is now parsed case-insensitively (via the existing `SeverityReader`).
- `ErrorReporter` gains a `catch (SarbException)` arm → **new exit code 18** for generic SARB errors.
- Interactive stdin (`stream_isatty`) fails fast: *"No static analysis results provided. Pipe the output of the static analysis tool into sarb."*
- `JsonUtils::toString()` uses `JSON_INVALID_UTF8_SUBSTITUTE` (invalid bytes become U+FFFD instead of a crash) and throws `SarbException` on residual failure.
- Punctuation fixes in two user-facing error messages; fixed a truncated docblock.

## Notes

- ⚠️ Conflicts trivially with #161, which adds exit code 17 in the same `ErrorReporter` spot — whichever merges second needs a one-line rebase.
- Full `composer ci` passes (100% coverage, PHPStan max, cs-fixer). New tests: invalid baseline values (unit + importer fixture), case-insensitive severity, exit 18 mapping, UTF-8 substitution, and a dedicated `SeverityTest`.