### PR TITLE
Fix escaping in JUnit and GitHub Actions output formats

### DIFF
--- a/src/Plugins/OutputFormatters/GithubActionsOutputFormatter.php
+++ b/src/Plugins/OutputFormatters/GithubActionsOutputFormatter.php
@@ -15,13 +15,12 @@ final class GithubActionsOutputFormatter implements OutputFormatter
         foreach ($analysisResults->getAnalysisResults() as $analysisResult) {
             $location = $analysisResult->getLocation();
 
-            $message = str_replace("\n", '%0A', $analysisResult->getMessage());
             $lines[] = sprintf(
                 '::%s file=%s,line=%d::%s',
                 $analysisResult->getSeverity()->getSeverity(),
-                $location->getRelativeFileName()->getFileName(),
+                $this->escapeProperty($location->getRelativeFileName()->getFileName()),
                 $location->getLineNumber()->getLineNumber(),
-                $message,
+                $this->escapeData($analysisResult->getMessage()),
             );
         }
 
@@ -31,5 +30,23 @@ final class GithubActionsOutputFormatter implements OutputFormatter
     public function getIdentifier(): string
     {
         return 'github';
+    }
+
+    /**
+     * Escapes a workflow command message. The GitHub Actions runner URL decodes these sequences,
+     * so a literal '%' must be escaped too, otherwise it corrupts the annotation.
+     */
+    private function escapeData(string $value): string
+    {
+        return str_replace(['%', "\r", "\n"], ['%25', '%0D', '%0A'], $value);
+    }
+
+    /**
+     * Escapes a workflow command property value. Unlike the message, property values must also
+     * have ':' and ',' escaped, otherwise they would terminate the property list.
+     */
+    private function escapeProperty(string $value): string
+    {
+        return str_replace(['%', "\r", "\n", ':', ','], ['%25', '%0D', '%0A', '%3A', '%2C'], $value);
     }
 }

--- a/src/Plugins/OutputFormatters/JunitOutputFormatter.php
+++ b/src/Plugins/OutputFormatters/JunitOutputFormatter.php
@@ -56,7 +56,7 @@ XML;
 
                 $testsuite = $test->addChild('testsuite');
                 Assert::notNull($testsuite, 'Can not add testsuite to XML');
-                $testsuite->addAttribute('name', $relativeFileName);
+                $testsuite->addAttribute('name', $this->sanitiseForXml($relativeFileName));
 
                 $previousRelativeFileName = $relativeFileName;
                 $caseCount = 0;
@@ -71,13 +71,13 @@ XML;
             );
             $testcase = $testsuite->addChild('testcase');
             Assert::notNull($testcase, 'Can not add testcase element to XML');
-            $testcase->addAttribute('name', $lineSprint);
+            $testcase->addAttribute('name', $this->sanitiseForXml($lineSprint));
             $failure = $testcase->addChild('failure');
             Assert::notNull($failure, 'Can not add failure element to XML');
             $failure->addAttribute('type', $analysisResult->getSeverity()->getSeverity());
             $failure->addAttribute(
                 'message',
-                $analysisResult->getMessage(),
+                $this->sanitiseForXml($analysisResult->getMessage()),
             );
             ++$caseCount;
         }
@@ -90,7 +90,9 @@ XML;
         $asXml = $test->asXML();
 
         if (is_string($asXml) && ('' !== $asXml)) {
-            $dom->loadXML($asXml);
+            if (!$dom->loadXML($asXml)) {
+                throw new SarbException('xml could not be parsed'); // @codeCoverageIgnore
+            }
         } else {
             throw new SarbException('xml could not be loaded'); // @codeCoverageIgnore
         }
@@ -126,5 +128,26 @@ XML;
             $testsuite->addAttribute('tests', (string) $caseCount);
             $testsuite->addAttribute('failures', (string) $caseCount);
         }
+    }
+
+    /**
+     * Removes characters that are not valid in an XML 1.0 document (e.g. most control
+     * characters). SimpleXML would write them to the attribute unescaped, producing a document
+     * that can not be parsed.
+     */
+    private function sanitiseForXml(string $value): string
+    {
+        $sanitised = preg_replace(
+            '/[^\x{0009}\x{000A}\x{000D}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u',
+            '',
+            $value,
+        );
+
+        if (null === $sanitised) {
+            // Value is not valid UTF-8. Keep printable ASCII characters only.
+            $sanitised = (string) preg_replace('/[^\x09\x0A\x0D\x20-\x7E]/', '', $value);
+        }
+
+        return $sanitised;
     }
 }

--- a/tests/Unit/Plugins/OutputFormatters/GithubActionsOutputFormatterTest.php
+++ b/tests/Unit/Plugins/OutputFormatters/GithubActionsOutputFormatterTest.php
@@ -2,7 +2,15 @@
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\OutputFormatters;
 
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\AbsoluteFileName;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\LineNumber;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Location;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Type;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\OutputFormatter\OutputFormatter;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResult;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResultsBuilder;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\OutputFormatters\GithubActionsOutputFormatter;
 
 final class GithubActionsOutputFormatterTest extends AbstractOutputFormatterTestCase
@@ -26,6 +34,31 @@ final class GithubActionsOutputFormatterTest extends AbstractOutputFormatterTest
 EOF;
 
         $this->assertIssuesOutput($expectedOutput);
+    }
+
+    public function testWorkflowCommandEscaping(): void
+    {
+        $projectRoot = ProjectRoot::fromCurrentWorkingDirectory('/');
+        $location = Location::fromAbsoluteFileName(
+            new AbsoluteFileName('/path,to/FILE:1.php'),
+            $projectRoot,
+            new LineNumber(10),
+        );
+        $analysisResult = new AnalysisResult(
+            $location,
+            new Type('TYPE_1'),
+            "50% of this message is broken\r\nSecond line",
+            [],
+            Severity::error(),
+        );
+        $analysisResultsBuilder = new AnalysisResultsBuilder();
+        $analysisResultsBuilder->addAnalysisResult($analysisResult);
+
+        // The GitHub Actions runner URL decodes %25/%0D/%0A in the message. Property values
+        // (e.g. file) additionally need ':' and ',' escaping or they terminate the property list.
+        $expectedOutput = '::error file=path%2Cto/FILE%3A1.php,line=10::50%25 of this message is broken%0D%0ASecond line';
+
+        $this->assertSame($expectedOutput, $this->getOutputFormatter()->outputResults($analysisResultsBuilder->build()));
     }
 
     protected function getOutputFormatter(): OutputFormatter

--- a/tests/Unit/Plugins/OutputFormatters/JunitOutputFormatterTest.php
+++ b/tests/Unit/Plugins/OutputFormatters/JunitOutputFormatterTest.php
@@ -2,7 +2,15 @@
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Plugins\OutputFormatters;
 
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\AbsoluteFileName;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\LineNumber;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Location;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Type;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\OutputFormatter\OutputFormatter;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResult;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResultsBuilder;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\OutputFormatters\JunitOutputFormatter;
 
 final class JunitOutputFormatterTest extends AbstractOutputFormatterTestCase
@@ -50,6 +58,46 @@ XML;
 
 XML;
         $this->assertIssuesOutput($expectedOutput);
+    }
+
+    public function testInvalidXmlCharactersAreRemoved(): void
+    {
+        // \x08 (backspace) is not valid in an XML 1.0 document. SimpleXML writes it to the
+        // attribute unescaped, previously producing a document that could not be parsed
+        // (the formatter then returned only an XML declaration).
+        $output = $this->getOutputForMessage("MESSAGE\x08WITH\x08CONTROL_CHARS");
+
+        $this->assertStringContainsString('message="MESSAGEWITHCONTROL_CHARS"', $output);
+        $this->assertStringContainsString('<testsuite name="FILE_1"', $output);
+    }
+
+    public function testInvalidUtf8IsReducedToAscii(): void
+    {
+        // \xE9 is é in ISO-8859-1; it is not valid UTF-8
+        $output = $this->getOutputForMessage("caf\xE9 message");
+
+        $this->assertStringContainsString('message="caf message"', $output);
+    }
+
+    private function getOutputForMessage(string $message): string
+    {
+        $projectRoot = ProjectRoot::fromCurrentWorkingDirectory('/');
+        $location = Location::fromAbsoluteFileName(
+            new AbsoluteFileName('/FILE_1'),
+            $projectRoot,
+            new LineNumber(10),
+        );
+        $analysisResult = new AnalysisResult(
+            $location,
+            new Type('TYPE_1'),
+            $message,
+            [],
+            Severity::error(),
+        );
+        $analysisResultsBuilder = new AnalysisResultsBuilder();
+        $analysisResultsBuilder->addAnalysisResult($analysisResult);
+
+        return $this->getOutputFormatter()->outputResults($analysisResultsBuilder->build());
     }
 
     protected function getOutputFormatter(): OutputFormatter


### PR DESCRIPTION
## JUnit

A violation message containing an XML-1.0-invalid character (e.g. `\x08`) produced a "report" consisting solely of `<?xml version="1.0"?>` — silent data loss. SimpleXML happily writes such characters into attributes, and `DOMDocument::loadXML()`'s failure was never checked.

- Attribute values (testsuite/testcase names, failure messages) are sanitised: XML-1.0-invalid characters removed; if the value isn't valid UTF-8 at all, it's reduced to printable ASCII.
- `loadXML()`'s return value is now checked (throws `SarbException` instead of silently continuing).

## GitHub Actions

Escaping now follows the workflow-command rules:

- **Message**: `%` → `%25` and `\r` → `%0D` added (previously only `\n` was escaped). The Actions runner URL-decodes these sequences, so a literal `%0A`/`%25` in a message was corrupted, and a bare CR truncated the annotation.
- **`file=` property**: fully escaped — a path containing `,` or `:` previously terminated the property list.

## Notes

- ⚠️ Overlaps with #161, which adds a `title=` property to the github format with its own `escapeProperty()` — whichever merges second needs a small rebase (resolution: keep both, `title` uses `escapeProperty()`).
- Full `composer ci` passes (100% coverage, PHPStan max, cs-fixer). New tests cover control characters, invalid UTF-8, and property/message escaping.