### PR TITLE
Import tool severities consistently across results parsers

### DIFF
--- a/src/Domain/Utils/ParseAtLocationException.php
+++ b/src/Domain/Utils/ParseAtLocationException.php
@@ -26,9 +26,4 @@ final class ParseAtLocationException extends SarbException
     {
         return new self("Issue parsing [$location]. {$e->getMessage()}", 0, $e);
     }
-
-    public static function issueParsingWithMessage(string $message, string $location): self
-    {
-        return new self("Issue parsing [$location]. $message");
-    }
 }

--- a/src/Plugins/ResultsParsers/PhanJsonResultsParser/PhanJsonResultsParser.php
+++ b/src/Plugins/ResultsParsers/PhanJsonResultsParser/PhanJsonResultsParser.php
@@ -38,6 +38,12 @@ final class PhanJsonResultsParser implements ResultsParser
     private const TYPE = 'check_name';
     private const MESSAGE = 'description';
     private const FILE_PATH = 'path';
+    private const SEVERITY = 'severity';
+
+    /**
+     * Phan severities: 0 (low), 5 (normal), 10 (critical).
+     */
+    private const SEVERITY_LOW = 0;
 
     public function convertFromString(string $resultsAsString, ProjectRoot $projectRoot): AnalysisResults
     {
@@ -90,12 +96,15 @@ final class PhanJsonResultsParser implements ResultsParser
             new LineNumber($lineAsInt),
         );
 
+        $severityAsInt = ArrayUtils::getIntValue($analysisResultAsArray, self::SEVERITY);
+        $severity = self::SEVERITY_LOW === $severityAsInt ? Severity::warning() : Severity::error();
+
         return new AnalysisResult(
             $location,
             $type,
             $message,
             $analysisResultAsArray,
-            Severity::error(),
+            $severity,
         );
     }
 

--- a/src/Plugins/ResultsParsers/PhpMagicNumberDetectorResultsParser/PhpMagicNumberDetectorResultsParser.php
+++ b/src/Plugins/ResultsParsers/PhpMagicNumberDetectorResultsParser/PhpMagicNumberDetectorResultsParser.php
@@ -33,7 +33,9 @@ final class PhpMagicNumberDetectorResultsParser implements ResultsParser
 
     public function convertFromString(string $resultsAsString, ProjectRoot $projectRoot): AnalysisResults
     {
-        $lines = explode(\PHP_EOL, $resultsAsString);
+        // Split on any line ending (the tool's output line endings depend on the OS it ran on)
+        $lines = preg_split('/\R/', $resultsAsString);
+        Assert::isArray($lines);
         $analysisResultsBuilder = new AnalysisResultsBuilder();
 
         foreach ($lines as $line) {

--- a/src/Plugins/ResultsParsers/PhpmdJsonResultsParser/PhpmdJsonResultsParser.php
+++ b/src/Plugins/ResultsParsers/PhpmdJsonResultsParser/PhpmdJsonResultsParser.php
@@ -32,6 +32,13 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\ParseAtLocationExc
  */
 final class PhpmdJsonResultsParser implements ResultsParser
 {
+    /**
+     * Violations with a priority of this value or lower (i.e. numerically greater) are treated
+     * as warnings. PHPMD priorities range from 1 (highest) to 5 (lowest); most rules default to
+     * priority 3.
+     */
+    private const LOWEST_PRIORITY_TREATED_AS_ERROR = 4;
+
     public function convertFromString(string $resultsAsString, ProjectRoot $projectRoot): AnalysisResults
     {
         $analysisResultsAsArray = JsonUtils::toArray($resultsAsString);
@@ -40,7 +47,7 @@ final class PhpmdJsonResultsParser implements ResultsParser
         try {
             $filesWithProblems = ArrayUtils::getArrayValue($analysisResultsAsArray, 'files');
         } catch (ArrayParseException $e) {
-            throw ParseAtLocationException::issueParsingWithMessage("Missing 'files' key", 'root level of JSON structure');
+            throw ParseAtLocationException::issueParsing($e, 'root level of JSON structure');
         }
 
         $fileNumber = 0;
@@ -112,12 +119,16 @@ final class PhpmdJsonResultsParser implements ResultsParser
             new LineNumber($lineAsInt),
         );
 
+        // PHPMD rule priorities range from 1 (highest) to 5 (lowest)
+        $priority = ArrayUtils::getIntValue($violation, 'priority');
+        $severity = $priority >= self::LOWEST_PRIORITY_TREATED_AS_ERROR ? Severity::warning() : Severity::error();
+
         return new AnalysisResult(
             $location,
             $type,
             $message,
             $violation,
-            Severity::error(),
+            $severity,
         );
     }
 

--- a/src/Plugins/ResultsParsers/PsalmJsonResultsParser/PsalmJsonResultsParser.php
+++ b/src/Plugins/ResultsParsers/PsalmJsonResultsParser/PsalmJsonResultsParser.php
@@ -48,11 +48,8 @@ final class PsalmJsonResultsParser implements ResultsParser
             ++$resultsCount;
             try {
                 ArrayUtils::assertArray($analysisResultAsArray);
-                $severity = ArrayUtils::getStringValue($analysisResultAsArray, self::SEVERITY);
-                if (self::ERROR_SEVERITY_LEVEL === $severity) {
-                    $analysisResult = $this->convertAnalysisResultFromArray($analysisResultAsArray, $projectRoot);
-                    $analysisResultsBuilder->addAnalysisResult($analysisResult);
-                }
+                $analysisResult = $this->convertAnalysisResultFromArray($analysisResultAsArray, $projectRoot);
+                $analysisResultsBuilder->addAnalysisResult($analysisResult);
             } catch (ArrayParseException|InvalidPathException $e) {
                 throw ParseAtLocationException::issueAtPosition($e, $resultsCount);
             }
@@ -81,12 +78,16 @@ final class PsalmJsonResultsParser implements ResultsParser
             new LineNumber($lineAsInt),
         );
 
+        // Psalm reports issues below the errorLevel threshold with severity "info"
+        $severityAsString = ArrayUtils::getStringValue($analysisResultAsArray, self::SEVERITY);
+        $severity = self::ERROR_SEVERITY_LEVEL === $severityAsString ? Severity::error() : Severity::warning();
+
         return new AnalysisResult(
             $location,
             new Type($typeAsString),
             ArrayUtils::getStringValue($analysisResultAsArray, self::MESSAGE),
             $analysisResultAsArray,
-            Severity::error(),
+            $severity,
         );
     }
 

--- a/tests/Unit/Plugins/ResultsParsers/PhanJsonResultsParser/PhanJsonResultsParserTest.php
+++ b/tests/Unit/Plugins/ResultsParsers/PhanJsonResultsParser/PhanJsonResultsParserTest.php
@@ -100,6 +100,31 @@ final class PhanJsonResultsParserTest extends TestCase
             Severity::error());
     }
 
+    public function testSeverityMapping(): void
+    {
+        $fileContents = $this->getResource('phan/phan-severities.json');
+        $analysisResults = $this->phanJsonResultsParser->convertFromString($fileContents, $this->projectRoot);
+
+        $this->assertCount(2, $analysisResults->getAnalysisResults());
+
+        $result1 = $analysisResults->getAnalysisResults()[0];
+        $result2 = $analysisResults->getAnalysisResults()[1];
+
+        // Phan severity 10 (critical) is imported as error
+        $this->assertMatch($result1,
+            'src/Critical.php',
+            9,
+            'PhanUndeclaredClass',
+            Severity::error());
+
+        // Phan severity 0 (low) is imported as warning
+        $this->assertMatch($result2,
+            'src/Low.php',
+            5,
+            'PhanUnreferencedUseNormal',
+            Severity::warning());
+    }
+
     public function testTypeGuesser(): void
     {
         $this->assertFalse($this->phanJsonResultsParser->showTypeGuessingWarning());

--- a/tests/Unit/Plugins/ResultsParsers/PhpMagicNumberDetectorResultsParser/PhpMagicNumberResultsParserTest.php
+++ b/tests/Unit/Plugins/ResultsParsers/PhpMagicNumberDetectorResultsParser/PhpMagicNumberResultsParserTest.php
@@ -73,6 +73,24 @@ final class PhpMagicNumberResultsParserTest extends TestCase
         );
     }
 
+    public function testCrlfLineEndings(): void
+    {
+        $projectRoot = ProjectRoot::fromProjectRoot('/vagrant/static-analysis-baseliner', '/home');
+
+        // Tool output line endings depend on the OS the tool ran on
+        $original = "src/File1.php:6. Magic number: 123\r\nsrc/File3.php:8. Magic number: 42\r\n";
+        $analysisResults = $this->phpMagicNumberDetectorResultsParser->convertFromString($original, $projectRoot);
+
+        $this->assertCount(2, $analysisResults->getAnalysisResults());
+
+        $result1 = $analysisResults->getAnalysisResults()[0];
+        $result2 = $analysisResults->getAnalysisResults()[1];
+
+        // The magic number (used as the type) must not include the carriage return
+        $this->assertMatch($result1, 'src/File1.php', 6, '123', Severity::error());
+        $this->assertMatch($result2, 'src/File3.php', 8, '42', Severity::error());
+    }
+
     public function testTypeGuesser(): void
     {
         $this->assertFalse($this->phpMagicNumberDetectorResultsParser->showTypeGuessingWarning());

--- a/tests/Unit/Plugins/ResultsParsers/PhpmdJsonResultsParser/PhpmdJsonResultsParserTest.php
+++ b/tests/Unit/Plugins/ResultsParsers/PhpmdJsonResultsParser/PhpmdJsonResultsParserTest.php
@@ -73,6 +73,23 @@ final class PhpmdJsonResultsParserTest extends TestCase
         );
     }
 
+    public function testPriorityMapping(): void
+    {
+        $projectRoot = ProjectRoot::fromProjectRoot('/vagrant/static-analysis-baseliner', '/home');
+        $original = $this->getResource('phpmd/phpmd_priorities.json');
+        $analysisResults = $this->phpmdResultsParser->convertFromString($original, $projectRoot);
+
+        $this->assertCount(4, $analysisResults->getAnalysisResults());
+
+        [$result1, $result2, $result3, $result4] = $analysisResults->getAnalysisResults();
+
+        // PHPMD priorities 1-3 are imported as errors, 4-5 as warnings
+        $this->assertMatch($result1, 'src/Foo.php', 10, 'HighPriorityRule', Severity::error());
+        $this->assertMatch($result2, 'src/Foo.php', 20, 'NormalPriorityRule', Severity::error());
+        $this->assertMatch($result3, 'src/Foo.php', 30, 'LowPriorityRule', Severity::warning());
+        $this->assertMatch($result4, 'src/Foo.php', 40, 'InformationRule', Severity::warning());
+    }
+
     public function testTypeGuesser(): void
     {
         $this->assertFalse($this->phpmdResultsParser->showTypeGuessingWarning());

--- a/tests/Unit/Plugins/ResultsParsers/PsalmJsonResultsParser/PsalmJsonResultsParserTest.php
+++ b/tests/Unit/Plugins/ResultsParsers/PsalmJsonResultsParser/PsalmJsonResultsParserTest.php
@@ -48,11 +48,12 @@ final class PsalmJsonResultsParserTest extends TestCase
     {
         $original = $this->getResource('psalm/psalm.json');
         $this->analysisResults = $this->psalmResultsParser->convertFromString($original, $this->projectRoot);
-        $this->assertCount(3, $this->analysisResults->getAnalysisResults());
+        $this->assertCount(4, $this->analysisResults->getAnalysisResults());
 
         $result1 = $this->analysisResults->getAnalysisResults()[0];
         $result2 = $this->analysisResults->getAnalysisResults()[1];
         $result3 = $this->analysisResults->getAnalysisResults()[2];
+        $result4 = $this->analysisResults->getAnalysisResults()[3];
 
         $this->assertMatch($result1,
             'src/Domain/ResultsParser/AnalysisResults.php',
@@ -65,14 +66,22 @@ final class PsalmJsonResultsParserTest extends TestCase
             $result1->getMessage(),
         );
 
+        // Psalm issues with severity "info" are imported as warnings
         $this->assertMatch($result2,
+            'src/Domain/ResultsParser/AnalysisResults.php',
+            71,
+            'MixedInferredReturnType',
+            Severity::warning(),
+        );
+
+        $this->assertMatch($result3,
             'src/Domain/Utils/JsonUtils.php',
             29,
             'MixedAssignment',
             Severity::error(),
         );
 
-        $this->assertMatch($result3,
+        $this->assertMatch($result4,
             'src/Plugins/PsalmJsonResultsParser/PsalmJsonResultsParser.php',
             90,
             'MixedAssignment',

--- a/tests/resources/phan/phan-severities.json
+++ b/tests/resources/phan/phan-severities.json
@@ -1,0 +1,30 @@
+[
+  {
+    "type": "issue",
+    "type_id": 6022,
+    "check_name": "PhanUnreferencedUseNormal",
+    "description": "NOOPError PhanUnreferencedUseNormal Possibly zero references to use statement",
+    "severity": 0,
+    "location": {
+      "path": "src/Low.php",
+      "lines": {
+        "begin": 5,
+        "end": 5
+      }
+    }
+  },
+  {
+    "type": "issue",
+    "type_id": 10056,
+    "check_name": "PhanUndeclaredClass",
+    "description": "CRITICAL PhanUndeclaredClass Reference to undeclared class",
+    "severity": 10,
+    "location": {
+      "path": "src/Critical.php",
+      "lines": {
+        "begin": 9,
+        "end": 9
+      }
+    }
+  }
+]

--- a/tests/resources/phpmd/phpmd_priorities.json
+++ b/tests/resources/phpmd/phpmd_priorities.json
@@ -1,0 +1,44 @@
+{
+  "version": "@project.version@",
+  "package": "phpmd",
+  "timestamp": "2020-07-27T22:11:44+00:00",
+  "files": [
+    {
+      "file": "\/vagrant\/static-analysis-baseliner\/src\/Foo.php",
+      "violations": [
+        {
+          "beginLine": 10,
+          "endLine": 10,
+          "description": "High priority issue.",
+          "rule": "HighPriorityRule",
+          "ruleSet": "Some Rules",
+          "priority": 1
+        },
+        {
+          "beginLine": 20,
+          "endLine": 20,
+          "description": "Normal priority issue.",
+          "rule": "NormalPriorityRule",
+          "ruleSet": "Some Rules",
+          "priority": 3
+        },
+        {
+          "beginLine": 30,
+          "endLine": 30,
+          "description": "Low priority issue.",
+          "rule": "LowPriorityRule",
+          "ruleSet": "Some Rules",
+          "priority": 4
+        },
+        {
+          "beginLine": 40,
+          "endLine": 40,
+          "description": "Information only issue.",
+          "rule": "InformationRule",
+          "ruleSet": "Some Rules",
+          "priority": 5
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Only PHP CodeSniffer and the two sarb formats honoured the severity supplied by the tool:

- **Psalm** silently *discarded* anything whose severity wasn't `error` — so `info` issues (below Psalm's `errorLevel`) could never be baselined at all.
- **Phan** provides a numeric severity (0 low / 5 normal / 10 critical) — hard-coded to `error`.
- **PHPMD** provides a rule priority (1 highest … 5 lowest) — hard-coded to `error`.

This made `--ignore-warnings` meaningless for these tools and inconsistent with PHPCS.

## Behaviour changes

| Tool | Before | After |
|---|---|---|
| Psalm `info` | dropped | imported as **warning** |
| Psalm `error` | error | error (unchanged) |
| Phan severity 0 | error | **warning** |
| Phan severity 5/10 | error | error (unchanged) |
| PHPMD priority 1–3 | error | error (unchanged) |
| PHPMD priority 4–5 | error | **warning** |

Baseline matching is unaffected (severity isn't part of the match), so existing baselines keep working; the visible difference is warning-severity output rows and, for Psalm, `info` issues appearing (suppressable with `--ignore-warnings`).

## Also in this PR

- **phpmnd**: output is now split on any line ending (`/\R/`) instead of `PHP_EOL` — CRLF output parsed on Linux previously left a `\r` inside the recorded magic number (breaking cross-platform baseline matching), and LF output on Windows didn't split at all.
- **PHPMD**: the missing-`files`-key error now keeps its underlying cause; the resulting orphaned `ParseAtLocationException::issueParsingWithMessage()` factory is removed.

Full `composer ci` passes (100% coverage, PHPStan max, cs-fixer).