### PR TITLE
Fix docker and CI tooling issues

### DIFF
--- a/.github/workflows/full-checks.yml
+++ b/.github/workflows/full-checks.yml
@@ -8,6 +8,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   full-checks:
     name: "PHP version ${{ matrix.php-version }}, deps. ${{ matrix.dependencies }}"
@@ -27,11 +34,11 @@ jobs:
           - "8.4"
           - "8.5"
         operating-system:
-          - "ubuntu-22.04"
+          - "ubuntu-24.04"
 
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
@@ -42,14 +49,14 @@ jobs:
 
       - name: Get composer cache directory
         id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-"
 
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
@@ -65,4 +72,3 @@ jobs:
 
       - name: "Full CI"
         run: "composer ci"
-

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,7 +3,7 @@
 use PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer;
 
 $finder = PhpCsFixer\Finder::create()
-    ->exclude('/tests/scratchpad')
+    ->exclude('scratchpad')
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/tests')
     ->in(__DIR__ . '/tools')

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
   environment:
     php:
-      version: 7.4.0
+      version: 8.2
 
 filter:
   excluded_paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ fi
 EOF
 
 # Sort out git
-RUN git config --global --add safe.directory /app
+RUN git config --system --add safe.directory /app
 
 WORKDIR /app/

--- a/ci/cache/.gitignore
+++ b/ci/cache/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/composer.json
+++ b/composer.json
@@ -61,19 +61,19 @@
       "@phpstan"
     ],
     "composer-validate" : "@composer validate --no-check-all --strict",
-    "lint" : "parallel-lint src tests",
+    "lint" : "parallel-lint --exclude tests/scratchpad src tests",
     "var-dump-checker" : "var-dump-check --ladybug --no-colors src",
     "cs" : "php-cs-fixer fix -v --dry-run",
     "cs-fix" : "php-cs-fixer fix -v",
     "phpstan" : "phpstan -n --no-progress  analyse",
     "test" : [
       "@putenv XDEBUG_MODE=coverage",
-      "phpunit --coverage-clover=reports/phpunit.xml"
+      "phpunit --coverage-clover=reports/clover.xml"
     ],
     "test-with-coverage-check" : [
       "@putenv XDEBUG_MODE=coverage",
-      "phpunit --coverage-clover=reports/phpunit.xml",
-      "coverage-check reports/phpunit.xml 100"
+      "phpunit --coverage-clover=reports/clover.xml",
+      "coverage-check reports/clover.xml 100"
     ]
 
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,14 @@ services:
       args:
         PHP_VERSION: ""
     tty: true
+    # Run as the host user so files written to the mounted volume (vendor, reports, test
+    # scratchpad, caches) are not owned by root on the host.
+    user: "${UID:-1000}:${GID:-1000}"
+    environment:
+      HOME: /tmp
+      COMPOSER_CACHE_DIR: /tmp/composer-cache
+      # Xdebug slows everything down; the composer test scripts enable it when needed.
+      XDEBUG_MODE: "${XDEBUG_MODE:-off}"
     volumes:
       - .:/app/:delegated
   php82:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
     </testsuite>
   </testsuites>
   <logging>
-    <junit outputFile="reports/coverage.xml"/>
+    <junit outputFile="reports/junit.xml"/>
   </logging>
   <source>
     <include>


### PR DESCRIPTION
## Docker: root-owned artifacts

The containers ran as root, so anything they wrote to the mounted volume (`vendor/` files, `reports/`, `.phpunit.cache/`, `tests/scratchpad/` — 67 accumulated root-owned dirs) was root-owned on the host, breaking subsequent non-docker runs (`composer install`, phpunit report writes, even a unit test that writes a scratch file).

- Compose services now run as `${UID:-1000}:${GID:-1000}` with `HOME=/tmp` and a tmp composer cache.
- `XDEBUG_MODE=off` by default in the containers — Xdebug was active for every in-container run; the composer test scripts already enable it where coverage is needed. Verified: `composer ci` in the rebuilt php84 container passes end-to-end as the mapped user.
- `safe.directory` moved from `--global` (root's HOME, invisible to the mapped user) to `--system`.

⚠️ **One-time manual cleanup needed** after merging: existing root-owned artifacts can't be deleted by the mapped user — run `sudo chown -R $(id -u):$(id -g) reports .phpunit.cache tests/scratchpad vendor` once.

## Broken scratchpad exclusions

`.php-cs-fixer.php` used `->exclude('/tests/scratchpad')`, but Finder `exclude()` takes paths relative to each `in()` dir — it matched nothing, so cs-fixer was scanning 60+ files inside generated test git repos (verified: finder picked up 63 scratchpad files; after the fix the scan drops from 289 to 222 files). Same gap fixed for `parallel-lint`.

## GitHub Actions

- `actions/checkout@v2` → `v4` (v2 runs a deprecated Node runtime scheduled for forced failure).
- `::set-output` (removed command syntax) → `$GITHUB_OUTPUT`.
- Added `permissions: contents: read` and a `concurrency` group that cancels superseded PR runs.
- `restore-keys` was identical to the primary key (useless) — now a proper prefix fallback.
- `ubuntu-22.04` → `ubuntu-24.04`.

## Misc

- The report filenames were swapped: junit XML went to `reports/coverage.xml` and clover coverage to `reports/phpunit.xml`. Now `reports/junit.xml` / `reports/clover.xml`.
- Scrutinizer PHP version bumped from 7.4.0 (unsupported on this codebase) to 8.2 — if Scrutinizer isn't used any more, dropping `.scrutinizer.yml` + the README badge might be better; happy to do that instead.
- Deleted the dead `ci/cache/` directory (unreferenced since the pre-Actions CI setup).