### PR TITLE
Test the stdout/stderr contract and tidy test infrastructure

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="tests/bootstrap.php" colors="true" processIsolation="false" stopOnFailure="false" failOnRisky="true" failOnWarning="true" beStrictAboutOutputDuringTests="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
     <report>
       <html outputDirectory="reports/coverage-html" highLowerBound="100"/>

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -80,9 +80,6 @@ final class EndToEndTest extends TestCase
             11,
             self::COMMIT_1_RESULTS,
         );
-
-        // Only delete test directory if tests passed. Keep to investigate test failures
-        $this->removeTestDirectory();
     }
 
     public function testInvalidAnalysisResults(): void
@@ -102,9 +99,6 @@ final class EndToEndTest extends TestCase
             13,
             self::INVALID_RESULTS,
         );
-
-        // Only delete test directory if tests passed. Keep to investigate test failures
-        $this->removeTestDirectory();
     }
 
     public function testInvalidProjectRoot(): void
@@ -124,9 +118,6 @@ final class EndToEndTest extends TestCase
             15,
             self::COMMIT_1_RESULTS,
         );
-
-        // Only delete test directory if tests passed. Keep to investigate test failures
-        $this->removeTestDirectory();
     }
 
     public function testInvalidBaselineFileNameSupplied(): void
@@ -141,9 +132,6 @@ final class EndToEndTest extends TestCase
             $arguments,
             14,
             self::COMMIT_1_RESULTS);
-
-        // Only delete test directory if tests passed. Keep to investigate test failures
-        $this->removeTestDirectory();
     }
 
     public function testInvalidBaselineContents(): void
@@ -160,9 +148,6 @@ final class EndToEndTest extends TestCase
             $arguments,
             12,
             self::COMMIT_1_RESULTS);
-
-        // Only delete test directory if tests passed. Keep to investigate test failures
-        $this->removeTestDirectory();
     }
 
     public function testHappyPath(): void
@@ -197,9 +182,6 @@ final class EndToEndTest extends TestCase
             0,
             '',
         );
-
-        // Only delete test directory if tests passed. Keep to investigate test failures
-        $this->removeTestDirectory();
     }
 
     public function testRelativePathFlagHasNoAffectWhenUsingAbsolutePaths(): void
@@ -226,9 +208,6 @@ final class EndToEndTest extends TestCase
             0,
             '',
         );
-
-        // Only delete test directory if tests passed. Keep to investigate test failures
-        $this->removeTestDirectory();
     }
 
     public function testAttemptToCreateBaselineWithNonCleanGitStatus(): void
@@ -249,8 +228,6 @@ final class EndToEndTest extends TestCase
             15,
             self::COMMIT_1_RESULTS,
         );
-
-        $this->removeTestDirectory();
     }
 
     public function testForceCreateBaselineWithNonCleanGitStatus(): void
@@ -272,9 +249,6 @@ final class EndToEndTest extends TestCase
             0,
             self::COMMIT_1_RESULTS,
         );
-
-        // Only delete test directory if tests passed. Keep to investigate test failures
-        $this->removeTestDirectory();
     }
 
     /**
@@ -341,27 +315,33 @@ final class EndToEndTest extends TestCase
             $arguments['--ignore-warnings'] = null;
         }
 
-        $output = $this->runCommand(
+        [$stdOut, $stdErr] = $this->runCommand(
             RemoveBaseLineFromResultsCommand::COMMAND_NAME,
             $arguments,
             $expectedExitCode,
             $psalmResults,
         );
 
-        $output = str_replace('\/', '/', $output);
-
-        $this->assertStringContainsString($expectedResultsJson, $output);
+        // The formatted results (and nothing else) must be on stdout, so that
+        // `sarb remove ... | consumer` receives clean output. Info goes to stderr.
+        $this->assertJsonStringEqualsJsonString(
+            '' === $expectedResultsJson ? '[]' : $expectedResultsJson,
+            $stdOut,
+        );
+        $this->assertStringContainsString('Issue count with baseline removed:', $stdErr);
     }
 
     /**
      * @param array<string, string|null> $arguments
+     *
+     * @return array{string, string} stdout and stderr
      */
     private function runCommand(
         string $commandName,
         array $arguments,
         int $expectedExitCode,
         ?string $resourceContainStdinContents,
-    ): string {
+    ): array {
         $command = $this->application->find($commandName);
         $commandTester = new CommandTester($command);
         $arguments['command'] = $command->getName();
@@ -371,11 +351,12 @@ final class EndToEndTest extends TestCase
             $commandTester->setInputs([$stdin]);
         }
 
-        $actualExitCode = $commandTester->execute($arguments);
-        $output = $commandTester->getDisplay();
-        $this->assertEquals($expectedExitCode, $actualExitCode, $output);
+        $actualExitCode = $commandTester->execute($arguments, ['capture_stderr_separately' => true]);
+        $stdOut = $commandTester->getDisplay();
+        $stdErr = $commandTester->getErrorOutput();
+        $this->assertEquals($expectedExitCode, $actualExitCode, "STDOUT:\n{$stdOut}\nSTDERR:\n{$stdErr}");
 
-        return $output;
+        return [$stdOut, $stdErr];
     }
 
     private function getBaselineFilePath(): string

--- a/tests/Integration/GitCliWrapperTest.php
+++ b/tests/Integration/GitCliWrapperTest.php
@@ -95,12 +95,10 @@ final class GitCliWrapperTest extends TestCase
     public function assertNotClean(): void
     {
         Assert::assertFalse($this->gitWrapper->isClean($this->projectRoot));
-        $this->removeTestDirectory();
     }
 
     private function assertClean(): void
     {
         Assert::assertTrue($this->gitWrapper->isClean($this->projectRoot));
-        $this->removeTestDirectory();
     }
 }

--- a/tests/Integration/TestDirectoryTrait.php
+++ b/tests/Integration/TestDirectoryTrait.php
@@ -6,6 +6,8 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
 
 trait TestDirectoryTrait
 {
+    private bool $testDirectoryCreated = false;
+
     private function createTestDirectory(): void
     {
         $dateTimeFolderName = date('Ymd_His');
@@ -15,6 +17,18 @@ trait TestDirectoryTrait
         $cwd = getcwd();
         $this->assertNotFalse($cwd);
         $this->projectRoot = ProjectRoot::fromProjectRoot($testDirectory, $cwd);
+        $this->testDirectoryCreated = true;
+    }
+
+    /**
+     * Removes the test directory if the test passed.
+     * Kept when the test failed, to help investigate the failure.
+     */
+    protected function tearDown(): void
+    {
+        if ($this->testDirectoryCreated && $this->status()->isSuccess()) {
+            $this->removeTestDirectory();
+        }
     }
 
     private function removeTestDirectory(): void

--- a/tests/Integration/UpgradeV0BaselineFilesTest.php
+++ b/tests/Integration/UpgradeV0BaselineFilesTest.php
@@ -110,8 +110,6 @@ final class UpgradeV0BaselineFilesTest extends TestCase
         $updatedBaselineContents = trim($fileReader->readFile($this->baseLineFileName));
         $expectedBaselineContents = trim($this->getResource("v0/{$file}.expected"));
         $this->assertSame($expectedBaselineContents, $updatedBaselineContents);
-
-        $this->removeTestDirectory();
     }
 
     public function testUpgradeFails(): void
@@ -127,7 +125,6 @@ final class UpgradeV0BaselineFilesTest extends TestCase
         $actualExitCode = $commandTester->execute($arguments);
 
         $this->assertSame(12, $actualExitCode);
-        $this->removeTestDirectory();
     }
 
     private function createOriginalBaselineFile(string $file): void

--- a/tests/Unit/Framework/Command/CreateBaseLineCommandTest.php
+++ b/tests/Unit/Framework/Command/CreateBaseLineCommandTest.php
@@ -95,10 +95,10 @@ EOF;
 
         $commandTester->execute([
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(0, $commandTester);
-        $this->assertResponseContains('Baseline created', $commandTester);
+        $this->assertStdErrContains('Baseline created', $commandTester);
     }
 
     public function testPickNonDefaultResultsParserWithGuessTypesSet(): void
@@ -114,10 +114,10 @@ EOF;
         $commandTester->execute([
             self::INPUT_FORMAT_OPTION => ResultsParserStubIdentifier::CODE,
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(0, $commandTester);
-        $this->assertResponseContains(
+        $this->assertStdOutContains(
             '[results-parser-stub] guesses the classification of violations. This means results might not be 100% accurate.',
             $commandTester,
         );
@@ -136,7 +136,7 @@ EOF;
         $commandTester->execute([
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
             self::HISTORY_ANALYSER => HistoryFactoryStub::CODE,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(0, $commandTester);
     }
@@ -154,10 +154,10 @@ EOF;
         $commandTester->execute([
             self::INPUT_FORMAT_OPTION => 'rubbish',
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(11, $commandTester);
-        $this->assertResponseContains(
+        $this->assertStdErrContains(
             'Invalid value [rubbish] for option [input-format]. Pick one of: sarb-json|results-parser-stub',
             $commandTester,
         );
@@ -176,10 +176,10 @@ EOF;
         $commandTester->execute([
             self::HISTORY_ANALYSER => 'rubbish',
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(11, $commandTester);
-        $this->assertResponseContains(
+        $this->assertStdErrContains(
             'Invalid value [rubbish] for option [history-analyser]. Pick one of: git|history-factory-stub',
             $commandTester,
         );
@@ -199,7 +199,7 @@ EOF;
             self::HISTORY_ANALYSER => HistoryFactoryStub::CODE,
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
             self::PROJECT_ROOT => '/tmp',
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(0, $commandTester);
     }
@@ -218,7 +218,7 @@ EOF;
             self::HISTORY_ANALYSER => HistoryFactoryStub::CODE,
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
             self::PROJECT_ROOT => '/tmp',
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(100, $commandTester);
     }
@@ -237,10 +237,10 @@ EOF;
             self::HISTORY_ANALYSER => HistoryFactoryStub::CODE,
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
             self::PROJECT_ROOT => '/tmp',
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(16, $commandTester);
-        $this->assertResponseContains('Tool failed', $commandTester);
+        $this->assertStdErrContains('Tool failed', $commandTester);
     }
 
     private function createCommandTester(
@@ -273,13 +273,27 @@ EOF;
 
     private function assertReturnCode(int $expectedReturnCode, CommandTester $commandTester): void
     {
-        $this->assertSame($expectedReturnCode, $commandTester->getStatusCode(), $commandTester->getDisplay());
+        $output = "STDOUT:\n{$commandTester->getDisplay()}\nSTDERR:\n{$commandTester->getErrorOutput()}";
+        $this->assertSame($expectedReturnCode, $commandTester->getStatusCode(), $output);
     }
 
-    private function assertResponseContains(string $expectedMessage, CommandTester $commandTester): void
+    /**
+     * Informational messages and errors are written to stderr.
+     */
+    private function assertStdErrContains(string $expectedMessage, CommandTester $commandTester): void
+    {
+        $output = $commandTester->getErrorOutput();
+        $position = strpos($output, $expectedMessage);
+        $this->assertNotFalse($position, "Can't find message [$expectedMessage] in stderr [$output]");
+    }
+
+    /**
+     * NOTE: the type guessing warning is currently written to stdout.
+     */
+    private function assertStdOutContains(string $expectedMessage, CommandTester $commandTester): void
     {
         $output = $commandTester->getDisplay();
         $position = strpos($output, $expectedMessage);
-        $this->assertNotFalse($position, "Can't find message [$expectedMessage] in [$output]");
+        $this->assertNotFalse($position, "Can't find message [$expectedMessage] in stdout [$output]");
     }
 }

--- a/tests/Unit/Framework/Command/RemoveBaseLineCommandTest.php
+++ b/tests/Unit/Framework/Command/RemoveBaseLineCommandTest.php
@@ -82,12 +82,13 @@ EOF;
 
         $commandTester->execute([
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(0, $commandTester);
-        $this->assertResponseContains('Latest analysis issue count: 2', $commandTester);
-        $this->assertResponseContains('Baseline issue count: 4', $commandTester);
-        $this->assertResponseContains('Issue count with baseline removed: 0', $commandTester);
+        $this->assertStdErrContains('Latest analysis issue count: 2', $commandTester);
+        $this->assertStdErrContains('Baseline issue count: 4', $commandTester);
+        $this->assertStdErrContains('Issue count with baseline removed: 0', $commandTester);
+        $this->assertStdOut("No issues\n", $commandTester);
     }
 
     public function test1NewIssues(): void
@@ -100,10 +101,10 @@ EOF;
 
         $commandTester->execute([
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(1, $commandTester);
-        $this->assertResponseContains('Issue count with baseline removed: 1', $commandTester);
+        $this->assertStdErrContains('Issue count with baseline removed: 1', $commandTester);
     }
 
     public function testPickNonDefaultOutputFormatter(): void
@@ -117,13 +118,10 @@ EOF;
         $commandTester->execute([
             self::OUTPUT_FORMAT_OPTION => OutputFormatterStub::CODE,
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(0, $commandTester);
-        $this->assertResponseContains(
-            '[stub output formatter: Issues since baseline 0]',
-            $commandTester,
-        );
+        $this->assertStdOut("[stub output formatter: Issues since baseline 0]\n", $commandTester);
     }
 
     public function testPickNonDefaultOutputFormatterWithIssues(): void
@@ -137,13 +135,10 @@ EOF;
         $commandTester->execute([
             self::OUTPUT_FORMAT_OPTION => OutputFormatterStub::CODE,
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(1, $commandTester);
-        $this->assertResponseContains(
-            '[stub output formatter: Issues since baseline 8]',
-            $commandTester,
-        );
+        $this->assertStdOut("[stub output formatter: Issues since baseline 8]\n", $commandTester);
     }
 
     public function testInvalidResultsParser(): void
@@ -157,10 +152,10 @@ EOF;
         $commandTester->execute([
             self::OUTPUT_FORMAT_OPTION => 'rubbish',
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(11, $commandTester);
-        $this->assertResponseContains(
+        $this->assertStdErrContains(
             'Invalid value [rubbish] for option [output-format]. Pick one of: table|stub',
             $commandTester,
         );
@@ -177,7 +172,7 @@ EOF;
         $commandTester->execute([
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
             self::PROJECT_ROOT => '/tmp',
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(0, $commandTester);
     }
@@ -192,7 +187,7 @@ EOF;
 
         $commandTester->execute([
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(100, $commandTester);
     }
@@ -208,14 +203,14 @@ EOF;
         $commandTester->execute([
             self::BASELINE_FILE_ARGUMENT => self::BASELINE_FILENAME,
             self::CLEAN_UP => true,
-        ]);
+        ], ['capture_stderr_separately' => true]);
 
         $this->assertReturnCode(0, $commandTester);
 
-        $this->assertResponseContains('Random 2 issues in the baseline to fix...', $commandTester);
-        $this->assertResponseContains('FILE: /FILE_2', $commandTester);
-        $this->assertResponseContains('| 2    | MESSAGE_1   |', $commandTester);
-        $this->assertResponseContains('| 2    | MESSAGE_0   |', $commandTester);
+        $this->assertStdErrContains('Random 2 issues in the baseline to fix...', $commandTester);
+        $this->assertStdErrContains('FILE: /FILE_2', $commandTester);
+        $this->assertStdErrContains('| 2    | MESSAGE_1   |', $commandTester);
+        $this->assertStdErrContains('| 2    | MESSAGE_0   |', $commandTester);
     }
 
     private function createCommandTester(
@@ -264,14 +259,26 @@ EOF;
 
     private function assertReturnCode(int $expectedReturnCode, CommandTester $commandTester): void
     {
-        $this->assertSame($expectedReturnCode, $commandTester->getStatusCode(), $commandTester->getDisplay());
+        $output = "STDOUT:\n{$commandTester->getDisplay()}\nSTDERR:\n{$commandTester->getErrorOutput()}";
+        $this->assertSame($expectedReturnCode, $commandTester->getStatusCode(), $output);
     }
 
-    private function assertResponseContains(string $expectedMessage, CommandTester $commandTester): void
+    /**
+     * Results (and nothing else) are written to stdout, so `sarb remove ... | consumer` works.
+     */
+    private function assertStdOut(string $expectedOutput, CommandTester $commandTester): void
     {
-        $output = $commandTester->getDisplay();
+        $this->assertSame($expectedOutput, $commandTester->getDisplay());
+    }
+
+    /**
+     * Informational messages and errors are written to stderr.
+     */
+    private function assertStdErrContains(string $expectedMessage, CommandTester $commandTester): void
+    {
+        $output = $commandTester->getErrorOutput();
         $position = strpos($output, $expectedMessage);
-        $this->assertNotFalse($position, "Can't find message [$expectedMessage] in [$output]");
+        $this->assertNotFalse($position, "Can't find message [$expectedMessage] in stderr [$output]");
     }
 
     private function getAnalysisResultsWithXResults(int $count): AnalysisResults

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,24 @@
+<?php
+
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+require __DIR__.'/../vendor/autoload.php';
+
+// Prune old scratchpad directories. They are kept when an integration test fails (to help
+// investigate the failure), but nothing else ever deletes them.
+$scratchpadDirectory = __DIR__.'/scratchpad';
+$entries = glob($scratchpadDirectory.'/*', \GLOB_ONLYDIR);
+if (false !== $entries) {
+    $cutoff = time() - (7 * 24 * 60 * 60);
+    $fileSystem = new Filesystem();
+    foreach ($entries as $entry) {
+        if (filemtime($entry) < $cutoff) {
+            try {
+                $fileSystem->remove($entry);
+            } catch (IOException) {
+                // E.g. directory owned by another user. Ignore.
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The untested output contract

SARB's core usage pattern is `tool | sarb remove baseline | consumer`, which depends on **results (and nothing else) going to stdout** with info/counts/errors on stderr. That contract was never tested: every command test used `CommandTester` without `capture_stderr_separately`, so both streams merged into `getDisplay()` and a regression (e.g. a summary line printed to stdout) would have passed the entire suite.

- All command tests now run with `capture_stderr_separately` and assert against the correct stream (`OutputWriter`'s `getErrorOutput()` branch is now actually exercised).
- Results on stdout are asserted **exactly** (stub formatter output, `No issues`, JSON payloads via JSON-equality).
- Fixed a vacuous assertion: the "no new issues" end-to-end cases previously did `assertStringContainsString('', $output)` — always true. They now assert the output is exactly an empty JSON array.
- Noted in passing: the create command's type-guessing warning goes to *stdout* (arguably belongs on stderr) — left as-is because #161 moves that code; can follow up after it merges.

## Scratchpad hygiene

Integration tests create git repos under `tests/scratchpad/` and only deleted them via an explicit call at the end of each passing test — any failure, error, or interruption leaked the directory forever (67 had accumulated). Now:

- `TestDirectoryTrait` deletes the directory in `tearDown()` when the test **passed** (keeping the existing keep-on-failure-for-investigation behaviour), removing 15 copy-pasted cleanup calls.
- A new `tests/bootstrap.php` prunes scratchpad directories older than 7 days (ignoring ones it can't delete, e.g. legacy root-owned dirs from docker).

## PHPUnit strictness

`failOnRisky`, `failOnWarning` and `beStrictAboutOutputDuringTests` are now enabled.

Full `composer ci` passes (100% coverage, PHPStan max, cs-fixer).