### PR TITLE
Refresh documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Continuous Integration](https://github.com/DaveLiddament/sarb/workflows/Full%20checks/badge.svg)](https://github.com/DaveLiddament/sarb/actions) 
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/DaveLiddament/sarb/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/DaveLiddament/sarb/?branch=master)
 [![PHPStan level 8](https://img.shields.io/badge/PHPStan-max%20level-brightgreen.svg)](https://github.com/DaveLiddament/sarb/blob/master/phpstan.neon)
-[![Code Coverage](https://img.shields.io/badge/Code%20coverage-100%25-brightgreen.svg)](https://github.com/DaveLiddament/sarb/blob/f2db1404c8f2acb0f813c7fb49624fe21e42a302/composer.json#L109)
+[![Code Coverage](https://img.shields.io/badge/Code%20coverage-100%25-brightgreen.svg)](https://github.com/DaveLiddament/sarb/blob/master/composer.json)
 
 * [Why SARB](#why-sarb)
 * [Requirements](#requirements)
@@ -169,7 +169,24 @@ That's no problem there are 3 methods to [integrate a static analysis tool](docs
 ## Output formats 
 
 The format for showing issues after the baseline is removed can be specified using `--output-format` option. 
-Possible values are: `table`, `text`, `json` or `github` (for GitHub actions).
+Possible values are: `table`, `text`, `json`, `junit` or `github` (for GitHub actions).
+
+## Exit codes
+
+`sarb remove` exits with code `0` when no issues have been introduced since the baseline, and `1` when new issues
+are found. This makes it suitable as a CI gate. `sarb create` exits with code `0` on success.
+
+Both commands report failures with the following exit codes:
+
+| Exit code | Meaning |
+|-----------|---------|
+| 11 | Invalid configuration (e.g. unknown input or output format) |
+| 12 | Failed to import the baseline file |
+| 13 | Failed to parse the static analysis results |
+| 14 | File access error (e.g. baseline file can not be read or written) |
+| 15 | History analyser error (e.g. problem running git or parsing the diff) |
+| 16 | The static analysis tool reported errors |
+| 100 | Unexpected error |
 
 ## Ignoring warnings
 
@@ -183,12 +200,12 @@ vendor/bin/phpcs src --report=json | vendor/bin/sarb remove phpcs.baseline --ign
 
 ## SARB with GitHub Actions
 
-If you're using `actions/checkout@v2` to check out your code you'll need to add set `fetch-depth` to `0`.
-By default `checkout` only gets that latest state of the code and none of the history. 
+If you're using `actions/checkout` to check out your code you'll need to set `fetch-depth` to `0`.
+By default `checkout` only gets the latest state of the code and none of the history. 
 SARB uses git, which needs the full git history, to track file changes since the baseline. 
 To get the full history checked out use this:
 ```
-- uses: actions/checkout@v2
+- uses: actions/checkout@v4
   with:
     fetch-depth: 0
 ```

--- a/docs/SarbFormat.md
+++ b/docs/SarbFormat.md
@@ -1,7 +1,12 @@
 # SARB format
 
 This document defines the `sarb.json` file format. If a static analysis tool provides an output in this format
-it will work directly with SARB.
+it will work directly with SARB, using the input format `sarb-json`:
+
+```shell
+<static analysis tool> | vendor/bin/sarb create --input-format="sarb-json" tool.baseline
+<static analysis tool> | vendor/bin/sarb remove tool.baseline
+```
 
 
 ## Motivation
@@ -40,4 +45,26 @@ It is very important `Type` must not have file name, class name, function or lin
   ... repeat for each issue ...   
 ]
 ```
+
+
+## Relative path variant
+
+If the static analysis tool reports paths relative to the project root (instead of absolute paths), use the
+input format `sarb-relative-json`. The format is the same except each issue has a `relative_path` key instead
+of `file`:
+
+```json
+[
+  {
+    "relative_path": "Controller/HomeController.php",
+    "line": 10,
+    "type": "MixedType",
+    "message" : "Cannot assign $asArray to a mixed type",
+    "severity": "error"
+  },
+  ... repeat for each issue ...   
+]
+```
+
+See also [notes on results with relative paths](ResultsWithRelativePaths.md).
 


### PR DESCRIPTION
- **Exit codes table in the README** — CI consumers script against these, but only `remove`'s 0/1 was discoverable without reading `ErrorReporter`. Documents 11–16 and 100. (Note: #161 adds exit 17 and #164 adds exit 18 — I'll add those rows once they merge, or they can be folded in here if this merges last.)
- **Output formats list** — `junit` existed but wasn't listed. (`toon` will need adding when its PR lands.)
- **GitHub Actions examples** — the README recommended `actions/checkout@v2`, which runs a deprecated Node runtime; now v4. The `fetch-depth: 0` advice (the actual point of the section) is unchanged.
- **Coverage badge link** — pointed at `composer.json#L109` in a 2019 commit; now links to master.
- **`docs/SarbFormat.md`** — now states the `--input-format` code (`sarb-json`) and documents the previously-undocumented `sarb-relative-json` variant (`relative_path` key instead of `file`).

One thing deliberately *not* included: a CHANGELOG. Tags exist up to 1.9.0 but there's no changelog or documented release process — happy to backfill one from the git history as a follow-up if wanted.