### PR TITLE
Assorted small clean-ups

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -6,3 +6,8 @@ services:
 
   DaveLiddament\StaticAnalysisResultsBaseliner\:
     resource: '../src/*'
+    # Value objects and exceptions are not services. Excluding them means a newly type hinted
+    # value object fails at container compile time rather than at runtime.
+    exclude:
+      - '../src/**/*Exception.php'
+      - '../src/Domain/Common/*'

--- a/src/Domain/OutputFormatter/InvalidOutputFormatterException.php
+++ b/src/Domain/OutputFormatter/InvalidOutputFormatterException.php
@@ -2,6 +2,8 @@
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Domain\OutputFormatter;
 
-final class InvalidOutputFormatterException extends \Exception
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\SarbException;
+
+final class InvalidOutputFormatterException extends SarbException
 {
 }

--- a/src/Domain/Pruner/PrunedResults.php
+++ b/src/Domain/Pruner/PrunedResults.php
@@ -28,4 +28,21 @@ final class PrunedResults
     {
         return $this->inputAnalysisResults;
     }
+
+    /**
+     * Returns the input results that matched the baseline (i.e. input results minus the pruned ones).
+     */
+    public function getBaseLinedResults(): AnalysisResults
+    {
+        $prunedAnalysisResults = $this->prunedResults->getAnalysisResults();
+
+        $baseLinedResults = [];
+        foreach ($this->inputAnalysisResults->getAnalysisResults() as $analysisResult) {
+            if (!in_array($analysisResult, $prunedAnalysisResults, true)) {
+                $baseLinedResults[] = $analysisResult;
+            }
+        }
+
+        return new AnalysisResults($baseLinedResults);
+    }
 }

--- a/src/Domain/Utils/FqcnRemover.php
+++ b/src/Domain/Utils/FqcnRemover.php
@@ -11,7 +11,7 @@ final class FqcnRemover
     /**
      * Removes anything that looks like a FQCN from the string.
      */
-    public function removeRqcn(string $raw): string
+    public function removeFqcn(string $raw): string
     {
         $parts = explode(' ', $raw);
         $outputParts = [];

--- a/src/Domain/Utils/StringUtils.php
+++ b/src/Domain/Utils/StringUtils.php
@@ -34,16 +34,6 @@ final class StringUtils
     }
 
     /**
-     * Returns true if $haystack ends with $needle.
-     */
-    public static function endsWith(string $needle, string $haystack): bool
-    {
-        $length = strlen($needle);
-
-        return substr($haystack, -$length) === $needle;
-    }
-
-    /**
      * Returns true if line is empty (or contains only white space).
      */
     public static function isEmptyLine(string $line): bool

--- a/src/Framework/Command/ListResultsParsesCommand.php
+++ b/src/Framework/Command/ListResultsParsesCommand.php
@@ -49,7 +49,7 @@ final class ListResultsParsesCommand extends Command
 
             $output->writeln(
                 sprintf(
-                    '    Create baseline:         <info>%s | sarb create --input-format="%s"</info>',
+                    '    Create baseline:         <info>%s | sarb create --input-format="%s" <baseline-file></info>',
                     $identifier->getToolCommand(),
                     $identifier->getCode(),
                 ),
@@ -57,7 +57,7 @@ final class ListResultsParsesCommand extends Command
 
             $output->writeln(
                 sprintf(
-                    '    Remove baseline results: <info>%s | sarb remove</info>',
+                    '    Remove baseline results: <info>%s | sarb remove <baseline-file></info>',
                     $identifier->getToolCommand(),
                 ),
             );

--- a/src/Framework/Command/RemoveBaseLineFromResultsCommand.php
+++ b/src/Framework/Command/RemoveBaseLineFromResultsCommand.php
@@ -53,6 +53,11 @@ final class RemoveBaseLineFromResultsCommand extends Command
     {
         $this->setDescription('Shows issues created since the baseline');
 
+        // The documentation tells users to run "sarb remove". That currently works because
+        // Symfony matches unambiguous abbreviations, but a real alias means adding another
+        // remove-* command in the future can not silently break every user's CI.
+        $this->setAliases(['remove']);
+
         $outputFormatters = $this->outputFormatterLookupService->getIdentifiers();
         $this->addOption(
             self::OUTPUT_FORMAT,
@@ -123,8 +128,9 @@ final class RemoveBaseLineFromResultsCommand extends Command
 
             $returnCode = $outputAnalysisResults->hasNoIssues() ? 0 : 1;
 
-            if ($showRandomIssues && !$prunedResults->getInputAnalysisResults()->hasNoIssues()) {
-                $randomIssues = $this->randomResultsPicker->getRandomResultsToFix($prunedResults->getInputAnalysisResults());
+            $baseLinedResults = $prunedResults->getBaseLinedResults();
+            if ($showRandomIssues && !$baseLinedResults->hasNoIssues()) {
+                $randomIssues = $this->randomResultsPicker->getRandomResultsToFix($baseLinedResults);
 
                 OutputWriter::writeToStdError(
                     $output,

--- a/src/Framework/Container/internal/AddCommandCompilerPass.php
+++ b/src/Framework/Container/internal/AddCommandCompilerPass.php
@@ -10,6 +10,7 @@
 
 namespace DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Container\internal;
 
+use Composer\InstalledVersions;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Container\Container;
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -18,14 +19,24 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class AddCommandCompilerPass implements CompilerPassInterface
 {
+    private const PACKAGE_NAME = 'dave-liddament/sarb';
+
     public function process(ContainerBuilder $container): void
     {
         $container->register(Application::class, Application::class);
         $definition = $container->getDefinition(Application::class);
+        $definition->setArguments(['SARB', $this->getVersion()]);
         $definition->setPublic(true);
         $taggedServices = $container->findTaggedServiceIds(Container::COMMAND_TAG);
         foreach (array_keys($taggedServices) as $id) {
             $definition->addMethodCall('add', [new Reference($id)]);
         }
+    }
+
+    private function getVersion(): string
+    {
+        return InstalledVersions::isInstalled(self::PACKAGE_NAME)
+            ? (InstalledVersions::getPrettyVersion(self::PACKAGE_NAME) ?? 'UNKNOWN')
+            : 'UNKNOWN';
     }
 }

--- a/src/Plugins/ResultsParsers/PhpstanJsonResultsParser/PhpstanJsonResultsParser.php
+++ b/src/Plugins/ResultsParsers/PhpstanJsonResultsParser/PhpstanJsonResultsParser.php
@@ -33,7 +33,8 @@ use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\ParseAtLocationExc
  * Handles PHPStan's JSON output.
  *
  * NOTE: SARB only deals with errors that are attached to a particular line in a file.
- * PHPStan can report general errors (not specific to file). These are ignored by SARB.
+ * PHPStan can report general errors (not specific to a file). If any of these are present SARB
+ * stops with an error, as they normally indicate the PHPStan run itself failed.
  */
 final class PhpstanJsonResultsParser implements ResultsParser
 {
@@ -121,7 +122,7 @@ final class PhpstanJsonResultsParser implements ResultsParser
         }
 
         $rawType = ArrayUtils::getStringValue($analysisResultAsArray, self::TYPE);
-        $type = $this->fqcnRemover->removeRqcn($rawType);
+        $type = $this->fqcnRemover->removeFqcn($rawType);
 
         $location = Location::fromAbsoluteFileName(
             $absoluteFileName,

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -5,7 +5,6 @@ namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Integration;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\RelativeFileName;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\Path;
-use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Utils\StringUtils;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Command\CreateBaseLineCommand;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Command\ListHistoryAnalysersCommand;
 use DaveLiddament\StaticAnalysisResultsBaseliner\Framework\Command\ListResultsParsesCommand;
@@ -406,7 +405,7 @@ final class EndToEndTest extends TestCase
         $files = scandir($directory);
         $this->assertNotFalse($files);
         foreach ($files as $file) {
-            if (StringUtils::endsWith('.json', $file)) {
+            if (str_ends_with($file, '.json')) {
                 $fullPath = Path::makeAbsolute($file, $directory);
                 $contents = file_get_contents($fullPath);
                 $this->assertNotFalse($contents);

--- a/tests/Unit/Core/Pruner/PrunedResultsTest.php
+++ b/tests/Unit/Core/Pruner/PrunedResultsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Unit\Core\Pruner;
+
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\BaseLine;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\ProjectRoot;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Common\Severity;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\Pruner\PrunedResults;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResult;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Domain\ResultsParser\AnalysisResults;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\GitDiffHistoryAnalyser\GitCommit;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Plugins\ResultsParsers\SarbJsonResultsParser\SarbJsonResultsParser;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Helpers\AnalysisResultsAdderTrait;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Tests\Helpers\BaseLineResultsBuilder;
+use DaveLiddament\StaticAnalysisResultsBaseliner\Tests\TestDoubles\HistoryFactoryStub;
+use PHPUnit\Framework\TestCase;
+
+final class PrunedResultsTest extends TestCase
+{
+    use AnalysisResultsAdderTrait;
+
+    /**
+     * @var AnalysisResult
+     */
+    private $baseLinedResult;
+
+    /**
+     * @var AnalysisResult
+     */
+    private $newResult;
+
+    protected function setUp(): void
+    {
+        $projectRoot = ProjectRoot::fromCurrentWorkingDirectory('/');
+        $this->baseLinedResult = $this->buildAnalysisResult($projectRoot, '/FILE_1', 1, 'TYPE_1', Severity::error());
+        $this->newResult = $this->buildAnalysisResult($projectRoot, '/FILE_2', 2, 'TYPE_2', Severity::error());
+    }
+
+    public function testGetters(): void
+    {
+        $baseLine = $this->createBaseLine();
+        $prunedAnalysisResults = new AnalysisResults([$this->newResult]);
+        $inputAnalysisResults = new AnalysisResults([$this->baseLinedResult, $this->newResult]);
+
+        $prunedResults = new PrunedResults($baseLine, $prunedAnalysisResults, $inputAnalysisResults);
+
+        $this->assertSame($baseLine, $prunedResults->getBaseLine());
+        $this->assertSame($prunedAnalysisResults, $prunedResults->getPrunedResults());
+        $this->assertSame($inputAnalysisResults, $prunedResults->getInputAnalysisResults());
+    }
+
+    public function testBaseLinedResultsAreInputResultsMinusPrunedResults(): void
+    {
+        $prunedResults = new PrunedResults(
+            $this->createBaseLine(),
+            new AnalysisResults([$this->newResult]),
+            new AnalysisResults([$this->baseLinedResult, $this->newResult]),
+        );
+
+        $baseLinedResults = $prunedResults->getBaseLinedResults();
+
+        $this->assertSame([$this->baseLinedResult], $baseLinedResults->getAnalysisResults());
+    }
+
+    public function testNoBaseLinedResultsWhenAllInputResultsAreNew(): void
+    {
+        $prunedResults = new PrunedResults(
+            $this->createBaseLine(),
+            new AnalysisResults([$this->baseLinedResult, $this->newResult]),
+            new AnalysisResults([$this->baseLinedResult, $this->newResult]),
+        );
+
+        $this->assertTrue($prunedResults->getBaseLinedResults()->hasNoIssues());
+    }
+
+    private function createBaseLine(): BaseLine
+    {
+        $baseLineResultsBuilder = new BaseLineResultsBuilder();
+        $baseLineResultsBuilder->add('FILE_1', 1, 'TYPE_1', Severity::error());
+
+        return new BaseLine(
+            new HistoryFactoryStub(),
+            $baseLineResultsBuilder->build(),
+            new SarbJsonResultsParser(),
+            new GitCommit('fae40b3d596780ffd746dbd2300d05dcfbd09033'),
+        );
+    }
+}

--- a/tests/Unit/Core/Utils/FqcnRemoverTest.php
+++ b/tests/Unit/Core/Utils/FqcnRemoverTest.php
@@ -33,7 +33,7 @@ final class FqcnRemoverTest extends TestCase
     public function testFqcnRemover(string $input, string $expected): void
     {
         $fqcnRemove = new FqcnRemover();
-        $actual = $fqcnRemove->removeRqcn($input);
+        $actual = $fqcnRemove->removeFqcn($input);
         $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/Unit/Core/Utils/StringUtilsTest.php
+++ b/tests/Unit/Core/Utils/StringUtilsTest.php
@@ -33,21 +33,6 @@ final class StringUtilsTest extends TestCase
         StringUtils::removeFromStart('Bar', 'FooBar');
     }
 
-    public function testDoesEndWith1(): void
-    {
-        $this->assertTrue(StringUtils::endsWith('e', 'abcde'));
-    }
-
-    public function testDoesEndWith2(): void
-    {
-        $this->assertTrue(StringUtils::endsWith('de', 'abcde'));
-    }
-
-    public function testDoesNotEndWith1(): void
-    {
-        $this->assertFalse(StringUtils::endsWith('d', 'abcde'));
-    }
-
     public function testIsEmpty(): void
     {
         $this->assertTrue(StringUtils::isEmptyLine(''));

--- a/tools/Phpat/LayerTest.php
+++ b/tools/Phpat/LayerTest.php
@@ -26,6 +26,16 @@ final class LayerTest
         ;
     }
 
+    public function testDomainDoesNotDependOnSymfony(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::DOMAIN_NAMESPACE))
+            ->shouldNotDependOn()
+            ->classes(Selector::inNamespace('Symfony'))
+            ->because('Domain code should not depend on the framework')
+        ;
+    }
+
     public function testsPluginDoesNotDependOnFrameworkLayer(): Rule
     {
         return PHPat::rule()


### PR DESCRIPTION
A collection of small fixes from a codebase review — none change matching/baselining behaviour:

- **`sarb remove` is now a real alias** of `remove-baseline-results`. The documented short form only worked via Symfony's unambiguous-abbreviation matching, so adding any future `remove-*` command would have silently broken every user's CI.
- **`list-static-analysis-tools` printed commands that fail** — both the create and remove examples were missing the mandatory `baseline-file` argument (verified: copy/pasting them yields `Not enough arguments`).
- **`--clean-up` sampled from the wrong set** — its help says *"issues in the baseline to fix"* but it sampled from *all* latest issues, including the brand-new ones just reported above it. Now samples from input-minus-pruned via a new `PrunedResults::getBaseLinedResults()`.
- **`sarb --version` printed "Console Tool"** — the application now has a name and a version (via `Composer\InstalledVersions`).
- **`FqcnRemover::removeRqcn()` → `removeFqcn()`** (long-standing typo).
- **`StringUtils::endsWith()` removed** — unused in src, subtly wrong for an empty needle, and PHP 8 has `str_ends_with`. (`startsWith` kept for now — it has many diff-parser callers and PR #162 touches those files.)
- **`InvalidOutputFormatterException` now extends `SarbException`** — `ErrorReporter`'s catch-all comment assumes every exception does; this was the only Domain exception outside the hierarchy.
- **Container hygiene** — exceptions and `Domain\Common` value objects are excluded from the autowiring sweep, so a newly type-hinted value object fails at compile time instead of at runtime.
- **New phpat rule** — Domain must not depend on Symfony (currently clean; the rule stops erosion).
- **PhpstanJsonResultsParser docblock** corrected (claimed general errors are "ignored"; SARB actually stops with an error).

## Conflicts with open PRs

- #161 rewrites the `FqcnRemover` call site in the PHPStan parser and adds its own `PrunedResultsTest` — whichever merges second needs a small rebase (I'm happy to do it).
- #164 adds an `ErrorReporter` catch arm near code this PR doesn't touch — should merge cleanly.

Full `composer ci` passes (100% coverage, PHPStan max incl. the new phpat rule, cs-fixer).